### PR TITLE
Updates for 64 bit time.

### DIFF
--- a/linux-user/hexagon/syscall_nr.h
+++ b/linux-user/hexagon/syscall_nr.h
@@ -104,7 +104,7 @@
 #define TARGET_NR_waitid 95
 #define TARGET_NR_set_tid_address 96
 #define TARGET_NR_unshare 97
-#define TARGET_NR_futex 98
+#define TARGET_NR_futex_time64 98
 #define TARGET_NR_set_robust_list 99
 #define TARGET_NR_get_robust_list 100
 #define TARGET_NR_nanosleep 101
@@ -118,8 +118,8 @@
 #define TARGET_NR_timer_getoverrun 109
 #define TARGET_NR_timer_settime 110
 #define TARGET_NR_timer_delete 111
-#define TARGET_NR_clock_settime 112
-#define TARGET_NR_clock_gettime 113
+#define TARGET_NR_clock_settime64 112
+#define TARGET_NR_clock_gettime64 113
 #define TARGET_NR_clock_getres 114
 #define TARGET_NR_clock_nanosleep 115
 #define TARGET_NR_syslog 116


### PR DESCRIPTION
This pulls in some changes that have been made to qemu since the branch
for hexagon was made.

This patch in particular:

Author: Alistair Francis <alistair.francis@wdc.com>
Date:   Thu Mar 12 15:13:53 2020 -0700

    linux-user/syscall: Add support for clock_gettime64/clock_settime64

    Add support for the clock_gettime64/clock_settime64 syscalls.