### PR TITLE
Correct QEMU_GENERATE implementations for fLSBNEW0/fLSBNEW1

### DIFF
--- a/target/hexagon/macros.h
+++ b/target/hexagon/macros.h
@@ -248,8 +248,8 @@ static inline void gen_pred_cancel(TCGv pred, int slot_num)
 
 #ifdef QEMU_GENERATE
 #define fLSBNEW(PVAL)   tcg_gen_mov_tl(LSB, (PVAL))
-#define fLSBNEW0        fLSBNEW(0)
-#define fLSBNEW1        fLSBNEW(1)
+#define fLSBNEW0        tcg_gen_mov_tl(LSB, hex_new_pred_value[0])
+#define fLSBNEW1        tcg_gen_mov_tl(LSB, hex_new_pred_value[1])
 #else
 #define fLSBNEW(PVAL)   (PVAL)
 #define fLSBNEW0        new_pred_value(env, 0)


### PR DESCRIPTION
Note that QEMU_GENERATE/fLSBNEW0 is only usedin SL2_return_tnew
Note that QEMU_GENERATE/fLSNBEW1 is not currently used