### PR TITLE
Hexagon (tests/tcg/hexagon) change rte to .word

### DIFF
--- a/tests/tcg/hexagon/privcheck.c
+++ b/tests/tcg/hexagon/privcheck.c
@@ -22,7 +22,7 @@ int err;
 int main()
 {
     /* Try to execute a priv instruction in user mode */
-    asm volatile("rte");
+    asm volatile(".word 0x57e0c000");     /* rte */
 
     puts(err ? "FAIL" : "PASS");
     return err;


### PR DESCRIPTION
Workaround for upstream LLVM toolchain

Signed-off-by: Taylor Simpson <tsimpson@quicinc.com>