### PR TITLE
Update initialization sequence to fix l2vic interrupts

### DIFF
--- a/hw/hexagon/hexagon_dsp.c
+++ b/hw/hexagon/hexagon_dsp.c
@@ -114,21 +114,6 @@ static void hexagon_common_init(MachineState *machine, Rev_t rev,
         HexagonCPU *cpu = HEXAGON_CPU(object_new(machine->cpu_type));
         qemu_register_reset(do_cpu_reset, cpu);
 
-        DeviceState *l2vic_dev;
-        l2vic_dev = sysbus_create_varargs("l2vic", m_cfg->l2vic_base,
-                /* IRQ#, Evnt#,CauseCode */
-                qdev_get_gpio_in(DEVICE(cpu), 0),
-                qdev_get_gpio_in(DEVICE(cpu), 1),
-                qdev_get_gpio_in(DEVICE(cpu), 2),
-                qdev_get_gpio_in(DEVICE(cpu), 3),
-                qdev_get_gpio_in(DEVICE(cpu), 4),
-                qdev_get_gpio_in(DEVICE(cpu), 5),
-                qdev_get_gpio_in(DEVICE(cpu), 6),
-                qdev_get_gpio_in(DEVICE(cpu), 7),
-                NULL);
-        sysbus_mmio_map(SYS_BUS_DEVICE(l2vic_dev), 1,
-            m_cfg->cfgtable.fastl2vic_base << 16);
-
         /*
          * CPU #0 is the only CPU running at boot, others must be
          * explicitly enabled via start instruction.
@@ -139,11 +124,28 @@ static void hexagon_common_init(MachineState *machine, Rev_t rev,
 
         if (i == 0) {
             hexagon_init_bootstrap(machine, cpu);
+            if (!qdev_realize_and_unref(DEVICE(cpu), NULL, errp)) {
+                return;
+            }
+            DeviceState *l2vic_dev;
+            l2vic_dev = sysbus_create_varargs("l2vic", m_cfg->l2vic_base,
+                    /* IRQ#, Evnt#,CauseCode */
+                    qdev_get_gpio_in(DEVICE(cpu), 0),
+                    qdev_get_gpio_in(DEVICE(cpu), 1),
+                    qdev_get_gpio_in(DEVICE(cpu), 2),
+                    qdev_get_gpio_in(DEVICE(cpu), 3),
+                    qdev_get_gpio_in(DEVICE(cpu), 4),
+                    qdev_get_gpio_in(DEVICE(cpu), 5),
+                    qdev_get_gpio_in(DEVICE(cpu), 6),
+                    qdev_get_gpio_in(DEVICE(cpu), 7),
+                    NULL);
+            sysbus_mmio_map(SYS_BUS_DEVICE(l2vic_dev), 1,
+                m_cfg->cfgtable.fastl2vic_base << 16);
         }
-
-        if (!qdev_realize_and_unref(DEVICE(cpu), NULL, errp)) {
+        else if (!qdev_realize_and_unref(DEVICE(cpu), NULL, errp)) {
             return;
         }
+
     }
 
     hexagon_config_table *config_table = &m_cfg->cfgtable;


### PR DESCRIPTION
Looks like qdev_realize_and_unref must be called first otherwise the associated irqs functions are null.