### PR TITLE
Update initialization sequence to fix l2vic interrupts

### DIFF
--- a/hw/hexagon/hexagon_dsp.c
+++ b/hw/hexagon/hexagon_dsp.c
@@ -124,6 +124,9 @@ static void hexagon_common_init(MachineState *machine, Rev_t rev,
 
         if (i == 0) {
             hexagon_init_bootstrap(machine, cpu);
+            if (!qdev_realize_and_unref(DEVICE(cpu), NULL, errp)) {
+                return;
+            }
             DeviceState *l2vic_dev;
             l2vic_dev = sysbus_create_varargs("l2vic", m_cfg->l2vic_base,
                     /* IRQ#, Evnt#,CauseCode */
@@ -138,9 +141,7 @@ static void hexagon_common_init(MachineState *machine, Rev_t rev,
                     NULL);
             sysbus_mmio_map(SYS_BUS_DEVICE(l2vic_dev), 1,
                 m_cfg->cfgtable.fastl2vic_base << 16);
-        }
-
-        if (!qdev_realize_and_unref(DEVICE(cpu), NULL, errp)) {
+        } else if (!qdev_realize_and_unref(DEVICE(cpu), NULL, errp)) {
             return;
         }
 


### PR DESCRIPTION
Looks like qdev_realize_and_unref must be called first otherwise the associated irqs functions are null.