### PR TITLE
Add check-tcg tests for sysmeu

### DIFF
--- a/hw/hexagon/hexagon_dsp.c
+++ b/hw/hexagon/hexagon_dsp.c
@@ -123,6 +123,8 @@ static void hexagon_common_init(MachineState *machine, Rev_t rev,
         qdev_prop_set_uint32(DEVICE(cpu), "l2vic-base-addr", m_cfg->l2vic_base);
         qdev_prop_set_uint32(DEVICE(cpu), "qtimer-base-addr", m_cfg->qtmr_rg0);
         qdev_prop_set_uint32(DEVICE(cpu), "config-table-addr", m_cfg->cfgbase);
+        qdev_prop_set_uint32(DEVICE(cpu), "hvx-contexts",
+                             m_cfg->cfgtable.ext_contexts);
 
         if (i == 0) {
             hexagon_init_bootstrap(machine, cpu);

--- a/target/hexagon/cpu.c
+++ b/target/hexagon/cpu.c
@@ -406,6 +406,15 @@ static void hexagon_cpu_reset_hold(Object *obj, ResetType type)
         arch_set_system_reg(env, HEX_SREG_MODECTL, 0x1);
         *(env->g_pcycle_base) = 0;
     }
+
+    memset(env->gpr, 0, sizeof(target_ulong) * TOTAL_PER_THREAD_REGS);
+    memset(env->pred, 0, sizeof(target_ulong) * NUM_PREGS);
+    memset(env->VRegs, 0, sizeof(MMVector) * NUM_VREGS);
+    memset(env->QRegs, 0, sizeof(MMQReg) * NUM_QREGS);
+    memset(env->vstore_pending, 0, sizeof(target_ulong) * VSTORES_MAX);
+    env->t_cycle_count = 0;
+    env->vtcm_pending = false;
+
     mmu_reset(env);
     arch_set_system_reg(env, HEX_SREG_HTID, cs->cpu_index);
     hexagon_cpu_soft_reset(env);

--- a/target/hexagon/cpu.c
+++ b/target/hexagon/cpu.c
@@ -29,6 +29,7 @@
 #include "cpu_helper.h"
 #include "max.h"
 #include "hex_mmu.h"
+#include "hw/hexagon/hexagon.h"
 
 #ifndef CONFIG_USER_ONLY
 #include "macros.h"
@@ -38,12 +39,19 @@
 #include "hexswi.h"
 #endif
 
-static void hexagon_v66_cpu_init(Object *obj) { }
-static void hexagon_v67_cpu_init(Object *obj) { }
-static void hexagon_v68_cpu_init(Object *obj) { }
-static void hexagon_v69_cpu_init(Object *obj) { }
-static void hexagon_v71_cpu_init(Object *obj) { }
-static void hexagon_v73_cpu_init(Object *obj) { }
+#define DEFINE_STD_CPU_INIT_FUNC(REV) \
+    static void hexagon_##REV##_cpu_init(Object *obj) \
+    { \
+        HexagonCPU *cpu = HEXAGON_CPU(obj); \
+        cpu->rev_reg = REV##_rev; \
+    }
+
+DEFINE_STD_CPU_INIT_FUNC(v66)
+DEFINE_STD_CPU_INIT_FUNC(v67)
+DEFINE_STD_CPU_INIT_FUNC(v68)
+DEFINE_STD_CPU_INIT_FUNC(v69)
+DEFINE_STD_CPU_INIT_FUNC(v71)
+DEFINE_STD_CPU_INIT_FUNC(v73)
 
 static ObjectClass *hexagon_cpu_class_by_name(const char *cpu_model)
 {
@@ -72,6 +80,7 @@ static const Property hexagon_cpu_properties[] = {
     DEFINE_PROP_UINT64("config-table-addr", HexagonCPU, config_table_addr,
                        0xffffffffULL),
 #endif
+    DEFINE_PROP_UINT32("dsp-rev", HexagonCPU, rev_reg, 0),
     DEFINE_PROP_BOOL("lldb-compat", HexagonCPU, lldb_compat, false),
     DEFINE_PROP_UNSIGNED("lldb-stack-adjust", HexagonCPU, lldb_stack_adjust, 0,
                          qdev_prop_uint32, target_ulong),
@@ -392,6 +401,7 @@ static void hexagon_cpu_reset_hold(Object *obj, ResetType type)
     memset(env->greg, 0, sizeof(target_ulong) * NUM_GREGS);
 
     if (cs->cpu_index == 0) {
+        arch_set_system_reg(env, HEX_SREG_REV, cpu->rev_reg);
         arch_set_system_reg(env, HEX_SREG_MODECTL, 0x1);
         *(env->g_pcycle_base) = 0;
     }

--- a/target/hexagon/cpu.c
+++ b/target/hexagon/cpu.c
@@ -93,9 +93,10 @@ const char * const hexagon_regnames[TOTAL_PER_THREAD_REGS] = {
   "r16", "r17", "r18", "r19", "r20",  "r21", "r22", "r23",
   "r24", "r25", "r26", "r27", "r28",  "r29", "r30", "r31",
   "sa0", "lc0", "sa1", "lc1", "p3_0", "c5",  "m0",  "m1",
-  "usr", "pc",  "ugp", "gp",  "cs0",  "cs1", "c14", "c15",
-  "c16", "c17", "c18", "c19", "pkt_cnt",  "insn_cnt", "hvx_cnt", "c23",
-  "c24", "c25", "c26", "c27", "c28",  "c29", "c30", "c31",
+  "usr", "pc",  "ugp", "gp",  "cs0",  "cs1", "upcyclelo", "upcyclehi",
+  "framelimit", "framekey", "pktcountlo", "pktcounthi", "upmucnt0",
+  "upmucnt1", "upmucnt2", "upmucnt3", "upmucnt4", "upmucnt5", "upmucnt6",
+  "upmucnt7",  "c28", "c29", "utimerlo", "utimerhi",
 };
 
 #ifndef CONFIG_USER_ONLY

--- a/target/hexagon/cpu.h
+++ b/target/hexagon/cpu.h
@@ -188,6 +188,7 @@ struct ArchCPU {
 
     CPUHexagonState env;
 
+    uint32_t rev_reg;
     bool lldb_compat;
     target_ulong lldb_stack_adjust;
     bool short_circuit;

--- a/target/hexagon/printinsn.c
+++ b/target/hexagon/printinsn.c
@@ -24,16 +24,17 @@
 
 static const char *sreg2str(unsigned int reg)
 {
-    if (reg < TOTAL_PER_THREAD_REGS) {
-        return hexagon_regnames[reg];
-    } else {
-        return "???";
+#ifndef CONFIG_USER_ONLY
+    if (reg < NUM_SREGS) {
+        return hexagon_sregnames[reg];
     }
+#endif
+    return "???";
 }
 
 static const char *creg2str(unsigned int reg)
 {
-    return sreg2str(reg + HEX_REG_SA0);
+    return hexagon_regnames[reg + HEX_REG_SA0];
 }
 
 static void snprintinsn(GString *buf, Insn *insn)

--- a/tests/tcg/hexagon/Makefile.softmmu-target
+++ b/tests/tcg/hexagon/Makefile.softmmu-target
@@ -35,11 +35,18 @@ tlb.o: crt0/tlb.c
 
 CRT0_OBJS=crt0.o crt0_standalone.o pte.o min_libc.o tlb.o
 
-TESTS += \
+TESTS_BUILT_WITH_DEFAULT_RULES = \
 	semihost \
+	mmu_overlap \
+	mmu_asids \
 	$()
 
-$(TESTS): $(CRT0_OBJS)
+TESTS += \
+	$(TESTS_BUILT_WITH_DEFAULT_RULES) \
+	tlb-miss-tlblock \
+	$()
+
+$(TESTS_BUILT_WITH_DEFAULT_RULES): $(CRT0_OBJS)
 
 # Build and link the tests
 echo-and-run = echo $(1) && $(1)
@@ -50,7 +57,7 @@ endef
 
 $(CRT0_OBJS):
 	$(call build_fn,$<,$@)
-$(TESTS):
+$(TESTS_BUILT_WITH_DEFAULT_RULES):
 	$(call build_fn,$^,$@,LINK)
 
 %.o: %.S
@@ -58,8 +65,20 @@ $(TESTS):
 %.o: %.c
 	$(call build_fn,$<,$@)
 
+mmu.h: ../hex_test.h
+
 semihost.o: semihost.c strutils.h
 semihost: semihost.o
+mmu_overlap.o: mmu_overlap.c mmu.h
+mmu_overlap: mmu_overlap.o
+mmu_asids.o: mmu_asids.c mmu.h
+mmu_asids: mmu_asids.o
+
+############# Custom build options
+
+# We don't want to link this one with crt0 files
+tlb-miss-tlblock: tlb-miss-tlblock.o
+	$(CC) $(CFLAGS) $< -o $@ -nostartfiles -Wl,-Ttext,0x9b800000 -Wl,-entry,0x9b800000
 
 ############# Custom test rules
 

--- a/tests/tcg/hexagon/Makefile.softmmu-target
+++ b/tests/tcg/hexagon/Makefile.softmmu-target
@@ -43,6 +43,8 @@ TESTS_BUILT_WITH_DEFAULT_RULES = \
 	ciad-siad \
 	badva \
 	vid_reg \
+	hvx-multi \
+	standalone_vec \
 	$()
 
 TESTS += \
@@ -80,10 +82,17 @@ mmu_asids: mmu_asids.o
 ciad-siad: ciad-siad.o
 standalone_hw: standalone_hw.o monitor_insts.o
 vid_reg: vid_reg.o
+hvx-multi.o: hvx-multi.c ../hvx_misc.h
+hvx-multi: hvx-multi.o
+standalone_vec.o: standalone_vec.c cfgtable.h
+standalone_vec: standalone_vec.o
 badva.o: badva.c ../hex_test.h crt0/hexagon_standalone.h
 badva: badva.o
 
 ############# Custom build options
+
+standalone_vec.o: CFLAGS+= -mv69 -O2 -mhvx  -fvectorize
+hvx-multi.o: CFLAGS+= -O2 -mhvx
 
 # We don't want to link this one with crt0 files
 tlb-miss-tlblock: tlb-miss-tlblock.o

--- a/tests/tcg/hexagon/Makefile.softmmu-target
+++ b/tests/tcg/hexagon/Makefile.softmmu-target
@@ -39,6 +39,8 @@ TESTS_BUILT_WITH_DEFAULT_RULES = \
 	semihost \
 	mmu_overlap \
 	mmu_asids \
+	standalone_hw \
+	ciad-siad \
 	$()
 
 TESTS += \
@@ -73,6 +75,8 @@ mmu_overlap.o: mmu_overlap.c mmu.h
 mmu_overlap: mmu_overlap.o
 mmu_asids.o: mmu_asids.c mmu.h
 mmu_asids: mmu_asids.o
+ciad-siad: ciad-siad.o
+standalone_hw: standalone_hw.o monitor_insts.o
 
 ############# Custom build options
 

--- a/tests/tcg/hexagon/Makefile.softmmu-target
+++ b/tests/tcg/hexagon/Makefile.softmmu-target
@@ -41,6 +41,8 @@ TESTS_BUILT_WITH_DEFAULT_RULES = \
 	mmu_asids \
 	standalone_hw \
 	ciad-siad \
+	badva \
+	vid_reg \
 	$()
 
 TESTS += \
@@ -77,6 +79,9 @@ mmu_asids.o: mmu_asids.c mmu.h
 mmu_asids: mmu_asids.o
 ciad-siad: ciad-siad.o
 standalone_hw: standalone_hw.o monitor_insts.o
+vid_reg: vid_reg.o
+badva.o: badva.c ../hex_test.h crt0/hexagon_standalone.h
+badva: badva.o
 
 ############# Custom build options
 

--- a/tests/tcg/hexagon/Makefile.softmmu-target
+++ b/tests/tcg/hexagon/Makefile.softmmu-target
@@ -45,6 +45,8 @@ TESTS_BUILT_WITH_DEFAULT_RULES = \
 	vid_reg \
 	hvx-multi \
 	standalone_vec \
+	fastl2vic \
+	int_range \
 	$()
 
 TESTS += \
@@ -88,6 +90,10 @@ standalone_vec.o: standalone_vec.c cfgtable.h
 standalone_vec: standalone_vec.o
 badva.o: badva.c ../hex_test.h crt0/hexagon_standalone.h
 badva: badva.o
+fastl2vic.o: fastl2vic.c cfgtable.h
+fastl2vic: fastl2vic.o
+int_range.o: int_range.c cfgtable.h
+int_range: int_range.o
 
 ############# Custom build options
 

--- a/tests/tcg/hexagon/Makefile.softmmu-target
+++ b/tests/tcg/hexagon/Makefile.softmmu-target
@@ -15,11 +15,10 @@ HEXAGON_SYSTEM_SRC=$(SRC_PATH)/tests/tcg/hexagon/system
 VPATH 		+= $(HEXAGON_SYSTEM_SRC)
 
 ########### Compiling options
-CC=hexagon-unknown-linux-musl-clang
 # We force -O0 to avoid optimizations that would break the
 # libc simplifications we made at min_libc.c
 #
-CFLAGS=-mv73 -G0 -nodefaultlibs -nostdlib -static -fno-PIC -O0 -g -Werror
+CFLAGS=-mv73 -U__linux__ -G0 -nodefaultlibs -nostdlib -static -fno-PIC -O0 -g -Werror
 LDFLAGS=-lclang_rt.builtins-hexagon
 
 ########### QEMU options

--- a/tests/tcg/hexagon/system/badva.c
+++ b/tests/tcg/hexagon/system/badva.c
@@ -1,0 +1,335 @@
+/*
+ *  Copyright(c) 2019-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "crt0/hexagon_standalone.h"
+
+#define DEBUG 0
+
+int err;
+#include "../hex_test.h"
+
+/* volatile because it is written through different MMU mappings */
+typedef volatile int mmu_variable;
+mmu_variable data0 = 0xdeadbeef;
+mmu_variable data1 = 0xabcdef01;
+
+#define ONE_MB (1 << 20)
+#define INVALID_BADVA 0xbadabada
+
+static uint32_t read_badva(void)
+{
+    uint32_t ret;
+    __asm__ __volatile__("%0 = badva\n\t" : "=r"(ret));
+    return ret;
+}
+
+static uint32_t read_badva0(void)
+{
+    uint32_t ret;
+    __asm__ __volatile__("%0 = badva0\n\t" : "=r"(ret));
+    return ret;
+}
+
+static uint32_t read_badva1(void)
+{
+    uint32_t ret;
+    __asm__ __volatile__("%0 = badva1\n\t" : "=r"(ret));
+    return ret;
+}
+
+static uint32_t read_ssr(void)
+{
+    uint32_t ret;
+    __asm__ __volatile__("%0 = ssr\n\t" : "=r"(ret));
+    return ret;
+}
+
+static void write_badva0(uint32_t val)
+{
+    __asm__ __volatile__("badva0=%0;" : : "r"(val));
+    return;
+}
+
+static void write_badva1(uint32_t val)
+{
+    __asm__ __volatile__("badva1=%0;" : : "r"(val));
+    return;
+}
+
+#define SSR_V0_BIT 20
+#define SSR_V1_BIT 21
+#define SSR_BVS_BIT 21
+
+static uint32_t read_ssr_v0(void)
+{
+    return (read_ssr() >> SSR_V0_BIT) & 0x1;
+}
+
+static uint32_t read_ssr_v1(void)
+{
+    return (read_ssr() >> SSR_V1_BIT) & 0x1;
+}
+
+static uint32_t read_ssr_bvs(void)
+{
+    return (read_ssr() >> SSR_BVS_BIT) & 0x1;
+}
+
+static void dual_store(mmu_variable *p, mmu_variable *q, uint32_t pval,
+                       uint32_t qval)
+{
+#if DEBUG
+    printf("dual_store:\t0x%p, 0x%p, 0x%lx, 0x%lx\n", p, q, pval, qval);
+#endif
+
+    __asm__ __volatile__("r6 = #0\n\t"
+                         "badva0 = r6\n\t"
+                         "badva1 = r6\n\t"
+                         "r6 = ssr\n\t"
+                         "r6 = clrbit(r6, #%4) // V0\n\t"
+                         "r6 = clrbit(r6, #%5) // V1\n\t"
+                         "r6 = clrbit(r6, #%6) // BVS\n\t"
+                         "ssr = r6\n\t"
+                         "{\n\t"
+                         "    memw(%0) = %2    // slot 1\n\t"
+                         "    memw(%1) = %3    // slot 0\n\t"
+                         "}\n\t"
+                         : "=m"(*p), "=m"(*q)
+                         : "r"(pval), "r"(qval), "i"(SSR_V0_BIT),
+                           "i"(SSR_V1_BIT), "i"(SSR_BVS_BIT)
+                         : "r6");
+}
+
+static void dual_load(mmu_variable *p, mmu_variable *q, uint32_t *pval,
+                      uint32_t *qval)
+{
+    uint32_t val0, val1;
+
+#if DEBUG
+    printf("dual_load:\t0x%p, 0x%p\n", p, q);
+#endif
+
+    __asm__ __volatile__("r6 = #0\n\t"
+                         "badva0 = r6\n\t"
+                         "badva1 = r6\n\t"
+                         "r6 = ssr\n\t"
+                         "r6 = clrbit(r6, #%4) // V0\n\t"
+                         "r6 = clrbit(r6, #%5) // V1\n\t"
+                         "r6 = clrbit(r6, #%6) // BVS\n\t"
+                         "ssr = r6\n\t"
+                         "{\n\t"
+                         "    %1 = memw(%3)    // slot 1\n\t"
+                         "    %0 = memw(%2)    // slot 0\n\t"
+                         "}\n\t"
+                         : "=r"(val0), "=r"(val1)
+                         : "m"(*p), "m"(*q), "i"(SSR_V0_BIT), "i"(SSR_V1_BIT),
+                           "i"(SSR_BVS_BIT)
+                         : "r6");
+
+#if DEBUG
+    printf("\t\t0x%lx, 0x%lx\n", val0, val1);
+#endif
+
+    *pval = val0;
+    *qval = val1;
+}
+
+static void load_store(mmu_variable *p, mmu_variable *q, uint32_t *pval,
+                       uint32_t qval)
+{
+    uint32_t val;
+
+#if DEBUG
+    printf("load_store:\t0x%p, 0x%p, 0x%lx\n", p, q, qval);
+#endif
+
+    __asm__ __volatile__("r6 = #0\n\t"
+                         "badva0 = r6\n\t"
+                         "badva1 = r6\n\t"
+                         "r6 = ssr\n\t"
+                         "r6 = clrbit(r6, #%4) // V0\n\t"
+                         "r6 = clrbit(r6, #%5) // V1\n\t"
+                         "r6 = clrbit(r6, #%6) // BVS\n\t"
+                         "ssr = r6\n\t"
+                         "{\n\t"
+                         "    %0 = memw(%2)    // slot 1\n\t"
+                         "    memw(%1) = %3    // slot 0\n\t"
+                         "}\n\t"
+                         : "=r"(val), "=m"(*q)
+                         : "m"(*p), "r"(qval), "i"(SSR_V0_BIT), "i"(SSR_V1_BIT),
+                           "i"(SSR_BVS_BIT)
+                         : "r6");
+
+#if DEBUG
+    printf("\t\t0x%lx\n", val);
+#endif
+
+    *pval = val;
+}
+
+enum {
+    TLB_U = (1 << 0),
+    TLB_R = (1 << 1),
+    TLB_W = (1 << 2),
+    TLB_X = (1 << 3),
+};
+
+uint32_t add_trans_pgsize(uint32_t page_size_bits)
+{
+    switch (page_size_bits) {
+    case 12: /* 4KB   */
+        return 1;
+    case 14: /* 16KB  */
+        return 2;
+    case 16: /* 64KB  */
+        return 4;
+    case 18: /* 256KB */
+        return 8;
+    case 20: /* 1MB   */
+        return 16;
+    case 22: /* 4MB   */
+        return 32;
+    case 24: /* 16MB  */
+        return 64;
+    default:
+        return 1;
+    }
+}
+
+int mb_counter = 1;
+
+static mmu_variable *map_data_address(mmu_variable *p, uint32_t data_offset)
+{
+    uint32_t page_size_bits = 12;
+    uint32_t page_size = 1 << page_size_bits;
+    uint32_t page_align = ~(page_size - 1);
+
+    uint32_t data_addr = (uint32_t)p;
+    uint32_t data_page = data_addr & page_align;
+
+    uint32_t new_data_page = data_page + data_offset;
+    uint32_t read_data_addr = data_addr + data_offset;
+    unsigned int data_perm = TLB_X | TLB_W | TLB_U;
+    add_translation((void *)new_data_page, (void *)data_page, 0);
+
+    return (mmu_variable *)read_data_addr;
+}
+
+static void test_dual_store(void)
+{
+    data0 = 0x12345678;
+    data1 = 0x87654321;
+
+    mmu_variable *new_data0 = map_data_address(&data0, mb_counter * ONE_MB);
+    mb_counter++;
+    mmu_variable *new_data1 = map_data_address(&data1, mb_counter * ONE_MB);
+    mb_counter++;
+
+    dual_store(new_data0, new_data1, 0x1, 0x2);
+    if (read_badva() == (uint32_t)new_data0) {
+        check32(read_badva0(), (uint32_t)new_data0);
+        check32(read_badva1(), INVALID_BADVA);
+        check32(read_ssr_v0(), 1);
+        check32(read_ssr_v1(), 0);
+        check32(read_ssr_bvs(), 0);
+    } else if (read_badva() == (uint32_t)new_data1) {
+        check32(read_badva0(), INVALID_BADVA);
+        check32(read_badva1(), (uint32_t)new_data1);
+        check32(read_ssr_v0(), 0);
+        check32(read_ssr_v1(), 1);
+        check32(read_ssr_bvs(), 1);
+    } else {
+        /* Something went wrong! */
+        check32(0, 1);
+    }
+    check32(data0, 0x1);
+    check32(data1, 0x2);
+}
+
+static void test_dual_load(void)
+{
+    uint32_t val0, val1;
+
+    data0 = 0xaabbccdd;
+    data1 = 0xeeff0011;
+
+    mmu_variable *new_data0 = map_data_address(&data0, mb_counter * ONE_MB);
+    mb_counter++;
+    mmu_variable *new_data1 = map_data_address(&data1, mb_counter * ONE_MB);
+    mb_counter++;
+
+    dual_load(new_data0, new_data1, &val0, &val1);
+    if (read_badva() == (uint32_t)new_data0) {
+        check32(read_badva0(), (uint32_t)new_data0);
+        check32(read_badva1(), INVALID_BADVA);
+        check32(read_ssr_v0(), 1);
+        check32(read_ssr_v1(), 0);
+        check32(read_ssr_bvs(), 0);
+    } else if (read_badva() == (uint32_t)new_data1) {
+        check32(read_badva0(), INVALID_BADVA);
+        check32(read_badva1(), (uint32_t)new_data1);
+        check32(read_ssr_v0(), 0);
+        check32(read_ssr_v1(), 1);
+        check32(read_ssr_bvs(), 1);
+    } else {
+        /* Something went wrong! */
+        check32(0, 1);
+    }
+    check32(val0, 0xaabbccdd);
+    check32(val1, 0xeeff0011);
+}
+
+static void test_load_store(void)
+{
+    uint32_t val;
+
+    data0 = 0x11223344;
+    data1 = 0x55667788;
+
+    mmu_variable *new_data0 = map_data_address(&data0, mb_counter * ONE_MB);
+    mb_counter++;
+    mmu_variable *new_data1 = map_data_address(&data1, mb_counter * ONE_MB);
+    mb_counter++;
+
+    load_store(new_data0, new_data1, &val, 0x123);
+    if (read_badva() == (uint32_t)new_data1) {
+        check32(read_badva0(), (uint32_t)new_data1);
+        check32(read_badva1(), INVALID_BADVA);
+        check32(read_ssr_v0(), 1);
+        check32(read_ssr_v1(), 0);
+        check32(read_ssr_bvs(), 0);
+    } else if (read_badva() == (uint32_t)new_data0) {
+        check32(read_badva0(), INVALID_BADVA);
+        check32(read_badva1(), (uint32_t)new_data0);
+        check32(read_ssr_v0(), 0);
+        check32(read_ssr_v1(), 1);
+        check32(read_ssr_bvs(), 1);
+    } else {
+        /* Something went wrong! */
+        check32(0, 1);
+    }
+    check32(val, 0x11223344);
+    check32(data1, 0x123);
+}
+static void test_badva_write(void)
+{
+    uint32_t va = 0x11223344;
+    write_badva0(va);
+    check32(read_badva(), va);
+}
+
+int main()
+{
+    puts("Hexagon badva test");
+
+    test_dual_store();
+    test_dual_load();
+    test_load_store();
+    test_badva_write();
+
+    printf("%s\n", ((err) ? "FAIL" : "PASS"));
+    return err;
+}

--- a/tests/tcg/hexagon/system/cfgtable.h
+++ b/tests/tcg/hexagon/system/cfgtable.h
@@ -1,0 +1,39 @@
+/*
+ *  Copyright(c) 2023-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef CFGTABLE_H
+#define CFGTABLE_H
+
+#include <stdint.h>
+
+static uint32_t read_cfgtable_field(uint32_t offset)
+{
+    uint32_t val;
+    asm volatile("r0 = cfgbase\n\t"
+                 "r0 = asl(r0, #5)\n\t"
+                 "%0 = memw_phys(%1, r0)\n\t"
+                 : "=r"(val)
+                 : "r"(offset)
+                 : "r0");
+    return val;
+}
+
+#define GET_SUBSYSTEM_BASE() (read_cfgtable_field(0x8) << 16)
+#define GET_FASTL2VIC_BASE() (read_cfgtable_field(0x28) << 16)
+
+static uintptr_t get_vtcm_base(void)
+{
+#if __HEXAGON_ARCH__ == 65
+    return 0xD8200000L;
+#elif __HEXAGON_ARCH__ >= 66
+    int vtcm_offset = 0x038;
+    return read_cfgtable_field(vtcm_offset) << 16;
+#else
+#error "unsupported hexagon revision"
+#endif
+}
+
+#endif /* CFGTABLE_H */

--- a/tests/tcg/hexagon/system/ciad-siad.c
+++ b/tests/tcg/hexagon/system/ciad-siad.c
@@ -1,0 +1,50 @@
+/*
+ *  Copyright(c) 2023-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+
+static inline void siad(uint32_t val)
+{
+    asm volatile ("siad(%0);"
+                  : : "r"(val));
+    return;
+}
+static inline void ciad(uint32_t val)
+{
+    asm volatile ("ciad(%0);"
+                  : : "r"(val));
+    return;
+}
+
+static inline uint32_t getipendad()
+{
+    uint32_t reg;
+    asm volatile ("%0=s20;"
+                  : "=r"(reg));
+    return reg;
+}
+int
+main(int argc, char *argv[])
+{
+    siad(4);
+    int ipend = getipendad();
+    if (ipend != (0x4 << 16)) {
+        goto fail;
+    }
+    ciad(4);
+    ipend = getipendad();
+    if (ipend) {
+        goto fail;
+    }
+
+    printf("PASS\n");
+    return 0;
+fail:
+    printf("FAIL\n");
+    return 1;
+}

--- a/tests/tcg/hexagon/system/fastl2vic.c
+++ b/tests/tcg/hexagon/system/fastl2vic.c
@@ -1,0 +1,73 @@
+/*
+ *  Copyright(c) 2024-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/*
+ * Test the fastl2vic interface.
+ *
+ *  hexagon-sim a.out --subsystem_base=0xfab0  --cosim_file q6ss.cfg
+ */
+
+#include "crt0/hexagon_standalone.h"
+
+#include "cfgtable.h"
+
+#define CSR_BASE  0xfab00000
+#define L2VIC_BASE ((CSR_BASE) + 0x10000)
+#define L2VIC_INT_ENABLE(b, n) \
+        ((unsigned int *) ((b) + 0x100 + 4 * (n / 32)))
+#define L2VIC_INT_ENABLE_SET(b, n) \
+        ((unsigned int *) ((b) + 0x200 + 4 * (n / 32)))
+
+int main()
+{
+    int ret = 0;
+    unsigned int irq_bit;
+
+    /* setup the fastl2vic interface and setup an indirect mapping */
+    volatile  uint32_t *A = (uint32_t *)0x888e0000;
+    add_translation_extended(3, (void *)A, GET_FASTL2VIC_BASE(), 16, 7, 4, 0, 0, 3);
+
+    uint32_t l2vic_base = GET_SUBSYSTEM_BASE() + 0x10000;
+
+    /* set and verify an interrupt using the L2VIC_BASE */
+    irq_bit  = (1 << (66  % 32));
+    *L2VIC_INT_ENABLE_SET(l2vic_base, 66)   = irq_bit;
+    if (*L2VIC_INT_ENABLE(l2vic_base, 64) != 0x4) {
+        ret = __LINE__;
+    }
+
+    /* set and verify an interrupt using the FASTL2VIC interface */
+    *A = 68;
+    if (*L2VIC_INT_ENABLE(l2vic_base, 64) != 0x14) {
+        ret = __LINE__;
+    }
+    *A = 67;
+    if (*L2VIC_INT_ENABLE(l2vic_base, 64) != 0x1C) {
+        ret = __LINE__;
+    }
+
+
+    /* Now clear the lines */
+    *A = ((1 << 16) | 68);
+    if (*L2VIC_INT_ENABLE(l2vic_base, 64) != 0xC) {
+        ret = __LINE__;
+    }
+    *A = ((1 << 16) | 66);
+    if (*L2VIC_INT_ENABLE(l2vic_base, 64) != 0x8) {
+        ret = __LINE__;
+    }
+    *A = ((1 << 16) | 67);
+    if (*L2VIC_INT_ENABLE(l2vic_base, 64) != 0x0) {
+        ret = __LINE__;
+    }
+
+    if (ret) {
+        printf("%s: FAIL, last failure near line %d\n", __FILE__, ret);
+    } else {
+        printf("PASS\n");
+    }
+    return ret;
+}

--- a/tests/tcg/hexagon/system/hvx-multi.c
+++ b/tests/tcg/hexagon/system/hvx-multi.c
@@ -1,0 +1,119 @@
+/*
+ *  Copyright(c) 2023-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+int err;
+
+#include "../hvx_misc.h"
+
+void set_hvx_context(int n)
+{
+    uint32_t ssr_context_bits = n << 27;
+    asm volatile(
+        "r1 = ssr\n"
+        "r1 = and(r1, ##0xc7ffffff)\n"
+        "r1 = or(r1, %0)\n"
+        "ssr = r1\r"
+        "isync\n"
+        :
+        : "r"(ssr_context_bits)
+        : "r1"
+    );
+}
+
+void setv0(int n)
+{
+    asm volatile(
+        "v0 = vsplat(%0)\n"
+        : : "r"(n) : "v0"
+    );
+}
+
+void store_v0(MMVector *v)
+{
+    asm volatile(
+        "vmemu(%0) = v0\n"
+        :
+        : "r"(v)
+        : "memory"
+    );
+}
+
+uint32_t get_num_contexts(void)
+{
+    const int EXT_CONTEXT_OFFSET = 13;
+    unsigned int cfgbase;
+    asm volatile("%0 = cfgbase\n" : "=r"(cfgbase));
+    uint32_t *cfgtable = (uint32_t *)(cfgbase << 16);
+    return *(cfgtable + EXT_CONTEXT_OFFSET);
+}
+
+uint32_t get_rev(void)
+{
+    uint32_t rev;
+    asm volatile("%0 = rev\n" : "=r"(rev));
+    return rev;
+}
+
+/*
+ * This test verifies that each new context is properly selected and is
+ * independent of the thread.
+ */
+int main()
+{
+    int num_contexts = get_num_contexts();
+    printf("rev=v%x, HVX-contexts=%d\n", (int)(get_rev() & 0xff), num_contexts);
+    memset(&output[0], 0, 8 * sizeof(MMVector));
+
+    /* First set v0 on all the contexts. */
+    for (int i = 0; i < num_contexts; i++) {
+        set_hvx_context(i);
+        setv0(i + 1);
+    }
+
+    /*
+     * Now each context should have its own v0 value. Save it to memory. We
+     * check all possible SSR.XA values to make sure the "aliases" are
+     * implemented correctly.
+     */
+    for (int i = 0; i < 8; i++) {
+        set_hvx_context(i);
+        store_v0(&output[i]);
+    }
+
+
+    /*
+     * Set expected values:
+     *
+     *                            num contexts
+     * SSR.XA     2              4              6              8
+     * 000      HVX Context 0  HVX Context 0  HVX Context 0  HVX Context 0
+     * 001      HVX Context 1  HVX Context 1  HVX Context 1  HVX Context 1
+     * 010      HVX Context 0  HVX Context 2  HVX Context 2  HVX Context 2
+     * 011      HVX Context 1  HVX Context 3  HVX Context 3  HVX Context 3
+     * 100      HVX Context 0  HVX Context 0  HVX Context 4  HVX Context 4
+     * 101      HVX Context 1  HVX Context 1  HVX Context 5  HVX Context 5
+     * 110      HVX Context 0  HVX Context 2  HVX Context 2  HVX Context 6
+     * 111      HVX Context 1  HVX Context 3  HVX Context 3  HVX Context 7
+     */
+    for (int i = 0; i < 8; i++) {
+        int expected = (i % num_contexts) + 1;
+        /* Exception for num_contexts=6 */
+        if (num_contexts == 6 && i >= 6) {
+            expected = (i - 6 + 2) + 1;
+        }
+        for (int j = 0; j < MAX_VEC_SIZE_BYTES / 4; j++) {
+            expect[i].w[j] = expected;
+        }
+    }
+
+    check_output_w(__LINE__, 8);
+    puts(err ? "FAIL" : "PASS");
+    return !!err;
+}

--- a/tests/tcg/hexagon/system/int_range.c
+++ b/tests/tcg/hexagon/system/int_range.c
@@ -1,0 +1,94 @@
+/*
+ *  Copyright(c) 2023-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/*
+ * Test the range of the l2vic interface.
+ */
+
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include "cfgtable.h"
+
+#define L2VIC_INT_ENABLE(b, n)                                               \
+    ((volatile unsigned int *)((b) + 0x100 + 4 * (n / 32))) /* device mem */
+
+#define L2VIC_INT_ENABLE_SET(b, n)                                           \
+    ((volatile unsigned int *)((b) + 0x200 + 4 * (n / 32))) /* device mem */
+
+#define L2VIC_INT_ENABLE_CLEAR(b, n)                                         \
+    ((volatile unsigned int *)((b) + 0x180 + 4 * (n / 32))) /* device mem */
+
+#define L2VIC_SOFT_INT_SET(b, n)                                             \
+    ((volatile unsigned int *)((b) + 0x480 + 4 * (n / 32))) /* device mem */
+
+#define L2VIC_INT_TYPE(b, n)                                                 \
+    ((volatile unsigned int *)((b) + 0x280 + 4 * (n / 32))) /* device mem */
+
+volatile int pass; /* must use volatile */
+int g_irq;
+volatile uint32_t g_l2vic_base; /* must use volatile */
+
+
+/*
+ * When complete the irqlog will contain the value of the vid when the
+ * handler was active.
+ */
+#define INTMAX 1024
+#define LEFT_SET 666
+
+int main()
+{
+    unsigned int irq_bit;
+    unsigned int left_set = 0;
+    int ret = 0;
+
+    /* setup the fastl2vic interface and setup an indirect mapping */
+    g_l2vic_base = GET_SUBSYSTEM_BASE() + 0x10000;
+
+    /* Setup interrupts */
+    for (int irq = 1; irq < INTMAX; irq++) {
+        irq_bit = (1 << (irq % 32));
+        *L2VIC_INT_ENABLE(g_l2vic_base, irq) |= irq_bit;
+    }
+
+    /* Read them all back and check */
+    for (int irq = 1; irq < INTMAX; irq++) {
+        if ((*L2VIC_INT_ENABLE(g_l2vic_base, irq) & (1 << (irq % 32))) !=
+            (1 << irq % 32)) {
+            printf("%d: ERROR: irq: %d: 0x%x\n", __LINE__, irq,
+                   *L2VIC_INT_ENABLE(g_l2vic_base, irq));
+            ret = 1;
+        }
+    }
+    /* Clear them all, except int 1 and LEFT_SET (test)  */
+    for (int irq = 1; irq < INTMAX; irq++) {
+        if (!(irq % LEFT_SET)) {
+            continue;
+        }
+        irq_bit = (1 << (irq % 32));
+        *L2VIC_INT_ENABLE_CLEAR(g_l2vic_base, irq) |= irq_bit;
+    }
+
+    /* make sure just LEFT_SET is set */
+    for (int irq = 0; irq < INTMAX; irq++) {
+        if ((*L2VIC_INT_ENABLE(g_l2vic_base, irq) & (1 << (irq % 32))) !=
+            (0 << irq % 32)) {
+            if (irq != LEFT_SET) {
+                printf("%d: ERROR: irq: %d: 0x%x\n", __LINE__, irq,
+                       *L2VIC_INT_ENABLE(g_l2vic_base, irq));
+                ret = 1;
+            } else {
+                left_set = irq;
+            }
+        }
+    }
+    if (left_set == LEFT_SET) {
+        printf("PASS\n");
+    }
+    return ret;
+}

--- a/tests/tcg/hexagon/system/mmu.h
+++ b/tests/tcg/hexagon/system/mmu.h
@@ -1,0 +1,718 @@
+/*
+ *  Copyright(c) 2019-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#ifndef MMU_H
+#define MMU_H
+#include <assert.h>
+#include <string.h>
+#include <stdint.h>
+#include "crt0/hexagon_standalone.h"
+
+/*
+ * Helpers for MMU tests
+ */
+
+#define TARGET_PAGE_BITS            12
+#ifndef TLB_NOT_FOUND
+#define TLB_NOT_FOUND               (1 << 31)
+#endif
+
+static inline uint32_t page_start(uint32_t addr, uint32_t page_size_bits)
+{
+    uint32_t page_size = 1 << page_size_bits;
+    uint32_t page_align = ~(page_size - 1);
+    return addr & page_align;
+}
+
+/*
+ * The Hexagon standalone runtime leaves TLB entries 1-5 reserved for
+ * user-defined entries.  We'll set them up to map virtual addresses at
+ * 1MB offsets above the actual physical address
+ *     PA == VA - (entry_num * 1MB)
+ *
+ * We'll define some macros/functions to help with the manipulation
+ */
+
+#define ONE_MB                      (1 << 20)
+#define TWO_MB                      (2 * ONE_MB)
+#define THREE_MB                    (3 * ONE_MB)
+#define FOUR_MB                     (4 * ONE_MB)
+#define FIVE_MB                     (5 * ONE_MB)
+
+#define ONE_MB_ENTRY                1
+#define TWO_MB_ENTRY                2
+#define THREE_MB_ENTRY              3
+#define FOUR_MB_ENTRY               4
+#define FIVE_MB_ENTRY               5
+
+static inline uint32_t tlb_entry_num(uint32_t va)
+{
+    return va >> 20;
+}
+
+#define fZXTN(N, M, VAL) ((VAL) & ((1LL << (N)) - 1))
+#define fEXTRACTU_BITS(INREG, WIDTH, OFFSET) \
+    (fZXTN(WIDTH, 32, (INREG >> OFFSET)))
+
+#define fINSERT_BITS(REG, WIDTH, OFFSET, INVAL) \
+    do { \
+        REG = ((REG) & ~(((1LL << (WIDTH)) - 1) << (OFFSET))) | \
+           (((INVAL) & ((1LL << (WIDTH)) - 1)) << (OFFSET)); \
+    } while (0)
+
+#define GET_FIELD(ENTRY, FIELD) \
+    fEXTRACTU_BITS(ENTRY, reg_field_info[FIELD].width, \
+                   reg_field_info[FIELD].offset)
+#define SET_FIELD(ENTRY, FIELD, VAL) \
+    fINSERT_BITS(ENTRY, reg_field_info[FIELD].width, \
+                 reg_field_info[FIELD].offset, (VAL))
+
+typedef struct {
+    int offset;
+    int width;
+} reg_field_t;
+
+enum reg_fields_enum {
+#define DEF_REG_FIELD(TAG, NAME, START, WIDTH, DESCRIPTION) \
+    TAG,
+#include "reg_fields_def.h"
+    NUM_REG_FIELDS
+#undef DEF_REG_FIELD
+};
+
+static const reg_field_t reg_field_info[] = {
+#define DEF_REG_FIELD(TAG, NAME, START, WIDTH, DESCRIPTION)    \
+      { START, WIDTH },
+
+#include "reg_fields_def.h"
+
+      { 0, 0 }
+#undef DEF_REG_FIELD
+};
+
+/*
+ * PPD (physical page descriptor) is formed by putting the PTE_PA35 field
+ * in the MSB of the PPD
+ */
+#define GET_PPD(ENTRY) \
+    ((GET_FIELD((ENTRY), PTE_PPD) | \
+     (GET_FIELD((ENTRY), PTE_PA35) << reg_field_info[PTE_PPD].width)))
+
+#define NUM_PGSIZE_TYPES (SHIFT_1G + 1)
+
+static const char *pgsize_str(PageSize pgsize)
+{
+    static const char *size_str[NUM_PGSIZE_TYPES] = {
+        "4K",
+        "16K",
+        "64K",
+        "256K",
+        "1M",
+        "4M",
+        "16M",
+        "64M",
+        "256M",
+        "1G"
+    };
+    assert(pgsize);
+    return size_str[__builtin_ctz(pgsize)];
+}
+
+static const uint64_t encmask_2_mask[] = {
+    0x0fffLL,                           /* 4k,   0000 */
+    0x3fffLL,                           /* 16k,  0001 */
+    0xffffLL,                           /* 64k,  0010 */
+    0x3ffffLL,                          /* 256k, 0011 */
+    0xfffffLL,                          /* 1m,   0100 */
+    0x3fffffLL,                         /* 4m,   0101 */
+    0xffffffLL,                         /* 16M,  0110 */
+    0xffffffffLL,                       /* RSVD, 0111 */
+};
+
+static inline int hex_tlb_pgsize(uint64_t entry)
+{
+    assert(entry != 0);
+    int size = __builtin_ctzll(entry);
+    assert(size < NUM_PGSIZE_TYPES);
+    return size;
+}
+
+static inline uint32_t hex_tlb_page_size(uint64_t entry)
+{
+    return 1 << (TARGET_PAGE_BITS + 2 * hex_tlb_pgsize(entry));
+}
+
+static inline uint64_t hex_tlb_phys_page_num(uint64_t entry)
+{
+    uint32_t ppd = GET_PPD(entry);
+    return ppd >> 1;
+}
+
+static inline uint64_t hex_tlb_phys_addr(uint64_t entry)
+{
+    uint64_t pagemask = encmask_2_mask[hex_tlb_pgsize(entry)];
+    uint64_t pagenum = hex_tlb_phys_page_num(entry);
+    uint64_t PA = (pagenum << TARGET_PAGE_BITS) & (~pagemask);
+    return PA;
+}
+
+static inline uint64_t hex_tlb_virt_addr(uint64_t entry)
+{
+    return GET_FIELD(entry, PTE_VPN) << TARGET_PAGE_BITS;
+}
+
+static inline uint64_t create_mmu_entry(uint8_t G, uint8_t A0, uint8_t A1,
+                                        uint8_t ASID, uint32_t VA,
+                                        uint8_t X, int8_t W, uint8_t R,
+                                        uint8_t U, uint8_t C, uint64_t PA,
+                                        PageSize SZ)
+{
+    uint64_t entry = 0;
+    SET_FIELD(entry, PTE_V, 1);
+    SET_FIELD(entry, PTE_G, G);
+    SET_FIELD(entry, PTE_ATR0, A0);
+    SET_FIELD(entry, PTE_ATR1, A1);
+    SET_FIELD(entry, PTE_ASID, ASID);
+    SET_FIELD(entry, PTE_VPN, VA >> TARGET_PAGE_BITS);
+    SET_FIELD(entry, PTE_X, X);
+    SET_FIELD(entry, PTE_W, W);
+    SET_FIELD(entry, PTE_R, R);
+    SET_FIELD(entry, PTE_U, U);
+    SET_FIELD(entry, PTE_C, C);
+    SET_FIELD(entry, PTE_PA35, (PA >> (TARGET_PAGE_BITS + 35)) & 1);
+    SET_FIELD(entry, PTE_PPD, ((PA >> (TARGET_PAGE_BITS - 1))));
+    entry |= SZ;
+    return entry;
+}
+
+static inline uint64_t tlbr(uint32_t i)
+{
+    uint64_t ret;
+    asm volatile ("%0 = tlbr(%1)\n\t" : "=r"(ret) : "r"(i));
+    return ret;
+}
+
+static inline uint32_t ctlbw(uint64_t entry, uint32_t idx)
+{
+    uint32_t ret;
+    asm volatile ("%0 = ctlbw(%1, %2)\n\t" : "=r"(ret) : "r"(entry), "r"(idx));
+    return ret;
+}
+
+static inline uint32_t tlbp(uint32_t asid, uint32_t VA)
+{
+    uint32_t x = ((asid & 0x7f) << 20) | ((VA >> 12) & 0xfffff);
+    uint32_t ret;
+    asm volatile ("%0 = tlbp(%1)\n\t" : "=r"(ret) : "r"(x));
+    return ret;
+}
+
+static inline void tlbw(uint64_t entry, uint32_t idx)
+{
+    asm volatile ("tlbw(%0, %1)\n\t" :: "r"(entry), "r"(idx));
+}
+
+static inline uint32_t tlboc(uint64_t entry)
+{
+    uint32_t ret;
+    asm volatile ("%0 = tlboc(%1)\n\t" : "=r"(ret) : "r"(entry));
+    return ret;
+}
+
+void tlbinvasid(uint32_t entry_hi)
+{
+    asm volatile ("tlbinvasid(%0)\n\t" :: "r"(entry_hi));
+}
+
+static inline void enter_user_mode(void)
+{
+    asm volatile ("r0 = ssr\n\t"
+                  "r0 = clrbit(r0, #17) // EX\n\t"
+                  "r0 = setbit(r0, #16) // UM\n\t"
+                  "r0 = clrbit(r0, #19) // GM\n\t"
+                  "ssr = r0\n\t" : : : "r0");
+}
+
+static inline void enter_kernel_mode(void)
+{
+    asm volatile ("r0 = ssr\n\t"
+                  "r0 = clrbit(r0, #17) // EX\n\t"
+                  "r0 = clrbit(r0, #16) // UM\n\t"
+                  "r0 = clrbit(r0, #19) // GM\n\t"
+                  "ssr = r0\n\t" : : : "r0");
+}
+
+static inline uint32_t *getevb()
+{
+    uint32_t reg;
+    asm volatile ("%0 = evb\n\t" : "=r"(reg));
+    return (uint32_t *)reg;
+}
+
+static inline void setevb(void *new_evb)
+{
+    asm volatile("evb = %0\n\t" : : "r"(new_evb));
+}
+
+static inline uint32_t getbadva()
+{
+    uint32_t badva;
+    asm volatile ("%0 = badva\n\t" : "=r"(badva));
+    return badva;
+}
+
+static void inc_elr(uint32_t inc)
+{
+
+    asm volatile ("r1 = %0\n\t"
+                  "r2 = elr\n\t"
+                  "r1 = add(r2, r1)\n\t"
+                  "elr = r1\n\t"
+                  :  : "r"(inc) : "r1", "r2");
+}
+
+static inline void do_coredump(void)
+{
+    asm volatile("r0 = #2\n\t"
+                 "stid = r0\n\t"
+                 "jump __coredump\n\t" : : : "r0");
+}
+
+static inline uint32_t getssr(void)
+{
+    uint32_t ret;
+    asm volatile ("%0 = ssr\n\t" : "=r"(ret));
+    return ret;
+}
+
+static inline void setssr(uint32_t new_ssr)
+{
+    asm volatile ("ssr = %0\n\t" :: "r"(new_ssr));
+}
+
+static inline void set_asid(uint32_t asid)
+{
+    uint32_t ssr = getssr();
+    SET_FIELD(ssr, SSR_ASID, asid);
+    setssr(ssr);
+}
+
+int err;
+#include "../hex_test.h"
+
+static void *old_evb;
+
+typedef uint64_t exception_vector[2];
+static exception_vector my_exceptions;
+
+static inline void clear_exception_vector(exception_vector excp)
+{
+    excp[0] = 0;
+    excp[1] = 0;
+}
+
+static inline void set_exception_vector_bit(exception_vector excp, uint32_t bit)
+{
+    if (bit < 64) {
+        excp[0] |= 1LL << bit;
+    } else if (bit < 128) {
+        excp[1] |= 1LL << (bit - 64);
+    }
+}
+
+#define check_exception_vector(excp, expect) \
+    do { \
+        check64(excp[0], expect[0]); \
+        check64(excp[1], expect[1]); \
+    } while (0)
+
+static inline void print_exception_vector(exception_vector excp)
+{
+    printf("exceptions (0x%016llx 0x%016llx):", excp[1], excp[0]);
+    for (int i = 0; i < 64; i++) {
+        if (excp[0] & (1LL << i)) {
+            printf(" 0x%x", i);
+        }
+    }
+    for (int i = 0; i < 64; i++) {
+        if (excp[1] & (1LL << i)) {
+            printf(" 0x%x", i + 64);
+        }
+    }
+    printf("\n");
+}
+
+/* volatile because it is written through different MMU mappings */
+typedef volatile int mmu_variable;
+mmu_variable data = 0xdeadbeef;
+
+typedef int (*func_t)(void);
+/* volatile because it will be invoked via different MMU mappings */
+typedef volatile func_t mmu_func_t;
+
+/*
+ * Create a function that returns its (virtual) address
+ * Write it fully in assembly so we don't have to worry about
+ * which optimization level we are compiled with
+ */
+extern int func_return_pc(void);
+asm(
+".global func_return_pc\n"
+".balign 4\n"
+".type func_return_pc, @function\n"
+"func_return_pc:\n"
+"    r0 = pc\n"
+"    jumpr r31\n"
+".size func_return_pc, . - func_return_pc\n"
+);
+
+enum {
+    TLB_U = (1 << 0),
+    TLB_R = (1 << 1),
+    TLB_W = (1 << 2),
+    TLB_X = (1 << 3),
+};
+
+#define HEX_CAUSE_FETCH_NO_XPAGE                  0x011
+#define HEX_CAUSE_FETCH_NO_UPAGE                  0x012
+#define HEX_CAUSE_PRIV_NO_READ                    0x022
+#define HEX_CAUSE_PRIV_NO_WRITE                   0x023
+#define HEX_CAUSE_PRIV_NO_UREAD                   0x024
+#define HEX_CAUSE_PRIV_NO_UWRITE                  0x025
+#define HEX_CAUSE_IMPRECISE_MULTI_TLB_MATCH       0x044
+#define HEX_CAUSE_TLBMISSX_NORMAL                 0x060
+#define HEX_CAUSE_TLBMISSX_NEXTPAGE               0x061
+#define HEX_CAUSE_TLBMISSRW_READ                  0x070
+#define HEX_CAUSE_TLBMISSRW_WRITE                 0x071
+
+/*
+ * The following lets us override the default exception handlers
+ * This can be handy for adding code to check that they are called as well
+ * as special handling needed for the test to succeed.
+ *
+ * MY_EVENT_HANDLE           Use this to define your own event handler
+ * DEFAULT_EVENT_HANDLE      Use this to point to the default handler
+ * my_event_vectors          New event vector table
+ * install_my_event_vectors  Change from the default event handlers
+ */
+
+extern void *my_event_vectors;
+
+#define MY_EVENT_HANDLE(name, helper) \
+void name(void) \
+{ \
+    asm volatile("crswap(sp, sgp0)\n\t" \
+                 "memd(sp++#8) = r1:0\n\t" \
+                 "memd(sp++#8) = r3:2\n\t" \
+                 "memd(sp++#8) = r5:4\n\t" \
+                 "memd(sp++#8) = r7:6\n\t" \
+                 "memd(sp++#8) = r9:8\n\t" \
+                 "memd(sp++#8) = r11:10\n\t" \
+                 "memd(sp++#8) = r13:12\n\t" \
+                 "memd(sp++#8) = r15:14\n\t" \
+                 "memd(sp++#8) = r17:16\n\t" \
+                 "memd(sp++#8) = r19:18\n\t" \
+                 "memd(sp++#8) = r21:20\n\t" \
+                 "memd(sp++#8) = r23:22\n\t" \
+                 "memd(sp++#8) = r25:24\n\t" \
+                 "memd(sp++#8) = r27:26\n\t" \
+                 "memd(sp++#8) = r31:30\n\t" \
+                 "r0 = ssr\n\t" \
+                 "call " #helper "\n\t" \
+                 "sp = add(sp, #-8)\n\t" \
+                 "r31:30 = memd(sp++#-8)\n\t" \
+                 "r27:26 = memd(sp++#-8)\n\t" \
+                 "r25:24 = memd(sp++#-8)\n\t" \
+                 "r23:22 = memd(sp++#-8)\n\t" \
+                 "r21:20 = memd(sp++#-8)\n\t" \
+                 "r19:18 = memd(sp++#-8)\n\t" \
+                 "r17:16 = memd(sp++#-8)\n\t" \
+                 "r15:14 = memd(sp++#-8)\n\t" \
+                 "r13:12 = memd(sp++#-8)\n\t" \
+                 "r11:10 = memd(sp++#-8)\n\t" \
+                 "r9:8 = memd(sp++#-8)\n\t" \
+                 "r7:6 = memd(sp++#-8)\n\t" \
+                 "r5:4 = memd(sp++#-8)\n\t" \
+                 "r3:2 = memd(sp++#-8)\n\t" \
+                 "r1:0 = memd(sp)\n\t" \
+                 "crswap(sp, sgp0);\n\t" \
+                 "rte\n\t"); \
+}
+
+#ifndef NO_DEFAULT_EVENT_HANDLES
+
+#define DEFAULT_EVENT_HANDLE(name, offset) \
+void name(void) \
+{ \
+    asm volatile("r0 = %0\n\t" \
+                 "r0 = add(r0, #" #offset ")\n\t" \
+                 "jumpr r0\n\t" \
+                 : : "r"(old_evb) : "r0"); \
+}
+
+
+/* Use these values as the offset for DEFAULT_EVENT_HANDLE */
+asm (
+".set HANDLE_RESET_OFFSET,               0x00\n\t"
+".set HANDLE_NMI_OFFSET,                 0x04\n\t"
+".set HANDLE_ERROR_OFFSET,               0x08\n\t"
+".set HANDLE_RSVD_OFFSET,                0x0c\n\t"
+".set HANDLE_TLBMISSX_OFFSET,            0x10\n\t"
+".set HANDLE_TLBMISSRW_OFFSET,           0x18\n\t"
+".set HANDLE_TRAP0_OFFSET,               0x20\n\t"
+".set HANDLE_TRAP1_OFFSET,               0x24\n\t"
+".set HANDLE_FPERROR_OFFSET,             0x28\n\t"
+".set HANDLE_INT_OFFSET,                 0x40\n\t"
+);
+
+asm(
+".align 0x1000\n\t"
+"my_event_vectors:\n\t"
+    "jump my_event_handle_reset\n\t"
+    "jump my_event_handle_nmi\n\t"
+    "jump my_event_handle_error\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_tlbmissx\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_tlbmissrw\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_trap0\n\t"
+    "jump my_event_handle_trap1\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_fperror\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_rsvd\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+    "jump my_event_handle_int\n\t"
+);
+
+#define DEFAULT_EVENT_HANDLES \
+DEFAULT_EVENT_HANDLE(my_event_handle_error,       HANDLE_ERROR_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_nmi,         HANDLE_NMI_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_tlbmissrw,   HANDLE_TLBMISSRW_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_tlbmissx,    HANDLE_TLBMISSX_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_reset,       HANDLE_RESET_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_rsvd,        HANDLE_RSVD_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_trap0,       HANDLE_TRAP0_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_trap1,       HANDLE_TRAP1_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_int,         HANDLE_INT_OFFSET) \
+DEFAULT_EVENT_HANDLE(my_event_handle_fperror,     HANDLE_FPERROR_OFFSET)
+
+#endif /* NO_DEFAULT_EVENT_HANDLES */
+
+/* When a permission error happens, add the permission to the TLB entry */
+void my_event_handle_error_helper(uint32_t ssr)
+{
+    uint32_t cause = GET_FIELD(ssr, SSR_CAUSE);
+    uint32_t badva = getbadva();
+    uint32_t entry_num = tlb_entry_num(badva);
+    uint64_t entry;
+
+    set_exception_vector_bit(my_exceptions, cause);
+
+    switch (cause) {
+    case HEX_CAUSE_FETCH_NO_XPAGE:
+        entry = tlbr(entry_num);
+        SET_FIELD(entry, PTE_X, 1);
+        tlbw(entry, entry_num);
+        break;
+    case HEX_CAUSE_FETCH_NO_UPAGE:
+        entry = tlbr(entry_num);
+        SET_FIELD(entry, PTE_U, 1);
+        tlbw(entry, entry_num);
+        break;
+    case HEX_CAUSE_PRIV_NO_READ:
+        entry = tlbr(entry_num);
+        SET_FIELD(entry, PTE_R, 1);
+        tlbw(entry, entry_num);
+        break;
+    case HEX_CAUSE_PRIV_NO_WRITE:
+        entry = tlbr(entry_num);
+        SET_FIELD(entry, PTE_W, 1);
+        tlbw(entry, entry_num);
+        break;
+    case HEX_CAUSE_PRIV_NO_UREAD:
+        entry = tlbr(entry_num);
+        SET_FIELD(entry, PTE_U, 1);
+        tlbw(entry, entry_num);
+        break;
+    case HEX_CAUSE_PRIV_NO_UWRITE:
+        entry = tlbr(entry_num);
+        SET_FIELD(entry, PTE_U, 1);
+        tlbw(entry, entry_num);
+        break;
+    default:
+        do_coredump();
+        break;
+    }
+}
+
+void my_event_handle_nmi_helper(uint32_t ssr)
+{
+    uint32_t cause = GET_FIELD(ssr, SSR_CAUSE);
+
+    set_exception_vector_bit(my_exceptions, cause);
+
+    switch (cause) {
+    case HEX_CAUSE_IMPRECISE_MULTI_TLB_MATCH:
+        break;
+    default:
+        do_coredump();
+        break;
+    }
+}
+
+/*
+ * When a TLB miss happens, create a mapping
+ * We'll set different read/write/execute permissions
+ * for different entry numbers.
+ */
+void my_event_handle_tlbmissrw_helper(uint32_t ssr)
+{
+    uint32_t cause = GET_FIELD(ssr, SSR_CAUSE);
+    uint32_t badva = getbadva();
+    uint32_t entry_num = tlb_entry_num(badva);
+    uint32_t VA = page_start(badva, TARGET_PAGE_BITS);
+    uint32_t PA = VA - (entry_num * ONE_MB);
+
+    uint64_t entry =
+        create_mmu_entry(1, 0, 0, 0, VA, 0, 0, 0, 1, 0x3, PA, PAGE_4K);
+    if (entry_num == TWO_MB_ENTRY) {
+        SET_FIELD(entry, PTE_R, 1);
+    }
+    if (entry_num == THREE_MB_ENTRY) {
+        SET_FIELD(entry, PTE_W, 1);
+    }
+
+    set_exception_vector_bit(my_exceptions, cause);
+
+    switch (cause) {
+    case HEX_CAUSE_TLBMISSRW_READ:
+        tlbw(entry, entry_num);
+        break;
+    case HEX_CAUSE_TLBMISSRW_WRITE:
+        tlbw(entry, entry_num);
+        break;
+    default:
+        do_coredump();
+        break;
+    }
+}
+
+void my_event_handle_tlbmissx_helper(uint32_t ssr)
+{
+    uint32_t cause = GET_FIELD(ssr, SSR_CAUSE);
+    uint32_t badva = getbadva();
+    uint32_t entry_num = tlb_entry_num(badva);
+    uint32_t VA = page_start(badva, TARGET_PAGE_BITS);
+    uint32_t PA = VA - (entry_num * ONE_MB);
+
+    uint64_t entry =
+        create_mmu_entry(1, 0, 0, 0, VA, 0, 0, 0, 1, 0x3, PA, PAGE_4K);
+
+    set_exception_vector_bit(my_exceptions, cause);
+
+    switch (cause) {
+    case HEX_CAUSE_TLBMISSX_NORMAL:
+        tlbw(entry, entry_num);
+        break;
+    default:
+        do_coredump();
+        break;
+    }
+}
+
+static inline void install_my_event_vectors(void)
+{
+    old_evb = getevb();
+    setevb(&my_event_vectors);
+}
+
+#define MAKE_GOTO(name) \
+void goto_##name(void) \
+{ \
+    asm volatile("r0 = ##" #name "\n\t" \
+                 "jumpr r0\n\t" \
+                 : : : "r0"); \
+}
+
+#define MAKE_ERR_HANDLER(name, helper_fn) \
+    MY_EVENT_HANDLE(name, helper_fn) \
+    MAKE_GOTO(name)
+
+#define INSTALL_ERR_HANDLER(name) { \
+    /*
+     * Install our own privelege exception handler.
+     * The normal behavior is to coredump
+     * Read and decode the jump displacemnts from evb
+     * ASSUME negative displacement which is the standard.
+     */ \
+    uint32_t *evb_err = getevb() + 2; \
+    uint32_t err_distance = -(0xfe000000 | *evb_err) << 1; \
+    uint32_t err_handler = (uint32_t)evb_err - err_distance; \
+    memcpy((void *)err_handler, goto_##name, 12); \
+} while (0)
+
+static inline void remove_trans(int index)
+{
+    uint64_t entry = tlbr(index);
+    SET_FIELD(entry, PTE_V, 0);
+    tlbw(entry, index);
+}
+
+static inline void clear_overlapping_entry(unsigned int asid, uint32_t va)
+{
+    int32_t index = tlbp(asid, va);
+    if (index != TLB_NOT_FOUND) {
+        remove_trans(index);
+    }
+}
+
+static void add_trans(int index, uint32_t va, uint64_t pa,
+                      PageSize page_size, uint8_t xwru,
+                      unsigned int asid, uint8_t V, uint8_t G)
+{
+    if (V) {
+        clear_overlapping_entry(asid, va);
+    }
+    assert(!add_translation_extended(index, (void *)va, pa, page_size,
+                                     xwru, 0, asid, 0,
+                                     ((V & 1) << 1) | (G & 1)));
+}
+
+#endif

--- a/tests/tcg/hexagon/system/mmu_asids.c
+++ b/tests/tcg/hexagon/system/mmu_asids.c
@@ -1,0 +1,80 @@
+/*
+ *  Copyright(c) 2019-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+
+#define DEBUG        0
+
+#include "mmu.h"
+
+DEFAULT_EVENT_HANDLES
+
+void test_asids(void)
+{
+    uint32_t addr = (uint32_t)&data;
+    uint32_t page = page_start(addr, TARGET_PAGE_BITS);
+    uint32_t offset = FIVE_MB;
+    uint32_t new_addr = addr + offset;
+    uint32_t new_page = page + offset;
+    uint64_t entry =
+        create_mmu_entry(0, 0, 0, 1, new_page, 1, 1, 1, 0, 7, page, PAGE_4K);
+    /*
+     * Create a TLB entry for ASID=1
+     * Write it at index 1
+     * Check that it is present
+     * Invalidate the ASID
+     * Check that it is not found
+     */
+    tlbw(entry, 1);
+    check32(tlboc(entry), 1);
+    tlbinvasid(entry >> 32);
+    check32(tlboc(entry), TLB_NOT_FOUND);
+
+    /*
+     * Re-install the entry
+     * Put ourselves in ASID=1
+     * Do a load and a store
+     */
+    data = 0xdeadbeef;
+    tlbw(entry, 1);
+    set_asid(1);
+    check32(*(mmu_variable *)new_addr, 0xdeadbeef);
+    *(mmu_variable *)new_addr = 0xcafebabe;
+    check32(data, 0xcafebabe);
+
+    /*
+     * Make sure a load from ASID 2 gets a different value.
+     * The standalone runtime will create a VA==PA entry on
+     * a TLB miss, so the load will be reading from uninitialized
+     * memory.
+     */
+    set_asid(2);
+    data = 0xdeadbeef;
+    check32_ne(*(mmu_variable *)new_addr, 0xdeadbeef);
+
+    /*
+     * Invalidate the ASID and make sure a loads from ASID 1
+     * gets a different value.
+     */
+    tlbinvasid(entry >> 32);
+    set_asid(1);
+    data = 0xcafebabe;
+    check32_ne(*(mmu_variable *)new_addr, 0xcafebabe);
+}
+
+int main()
+{
+    puts("Hexagon MMU ASID test");
+
+    test_asids();
+
+    printf("%s\n", ((err) ? "FAIL" : "PASS"));
+    return err;
+}

--- a/tests/tcg/hexagon/system/mmu_overlap.c
+++ b/tests/tcg/hexagon/system/mmu_overlap.c
@@ -1,0 +1,65 @@
+/*
+ *  Copyright(c) 2019-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+
+#define DEBUG        0
+
+#include "mmu.h"
+
+DEFAULT_EVENT_HANDLES
+
+void test_overlap(void)
+{
+    uint32_t addr = (uint32_t)&data;
+    uint32_t page = page_start(addr, 20);
+    uint32_t offset = FIVE_MB;
+    uint32_t new_page = page + offset;
+    uint32_t new_addr = addr + offset;
+    uint8_t data_perm = TLB_X | TLB_W | TLB_R | TLB_U;
+    uint64_t entry;
+
+    add_trans(1, new_page, page, PAGE_1M, data_perm, 0, 1, 1);
+    check32(tlbp(0, new_addr), 1);
+
+    /* Check an entry that overlaps with the one we just created */
+    entry =
+        create_mmu_entry(1, 0, 0, 0, new_page, 1, 1, 1, 0, 7, page, PAGE_4K);
+    check32(tlboc(entry), 1);
+    /* Check that conditional TLB write (ctlbw) does NOT write the new entry */
+    check32(ctlbw(entry, 2), 0x1);
+
+    /* Create an entry that does not overlap with the one we just created */
+    entry = create_mmu_entry(1, 0, 0, 0, new_page + ONE_MB, 1, 1, 1, 0, 7, page,
+                             PAGE_4K);
+    check32(tlboc(entry), TLB_NOT_FOUND);
+    /* Check that conditional TLB write (ctlbw) does write the new entry */
+    check32(ctlbw(entry, 2), TLB_NOT_FOUND);
+
+    /* Create an entry that overalps both of these entries */
+    entry =
+        create_mmu_entry(1, 0, 0, 0, new_page, 1, 1, 1, 0, 7, page, PAGE_4M);
+    check32(tlboc(entry), 0xffffffff);
+
+    /* Clear the TLB entries */
+    remove_trans(1);
+    check32(tlbp(0, new_addr), TLB_NOT_FOUND);
+    remove_trans(2);
+    check32(tlbp(0, (new_addr + ONE_MB)), TLB_NOT_FOUND);
+}
+
+int main()
+{
+    puts("Hexagon MMU overlap test");
+
+    test_overlap();
+
+    printf("%s\n", ((err) ? "FAIL" : "PASS"));
+    return err;
+}

--- a/tests/tcg/hexagon/system/monitor_insts.S
+++ b/tests/tcg/hexagon/system/monitor_insts.S
@@ -1,0 +1,18 @@
+/*
+ *  Copyright(c) 2020-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+    .text
+    .type test_set_prio, @function
+    .global test_set_prio
+
+test_set_prio:
+    r0 = #3
+    r1 = #1
+    p0 = cmp.eq(r0,r1)
+    setprio(p0, r0)
+    jumpr lr
+
+    .size test_set_prio, . - test_set_prio

--- a/tests/tcg/hexagon/system/reg_fields_def.h
+++ b/tests/tcg/hexagon/system/reg_fields_def.h
@@ -1,0 +1,87 @@
+/* PTE (aka TLB entry) fields */
+DEF_REG_FIELD(PTE_PPD,
+    "PPD", 0, 24,
+    "Physical page number that the corresponding virtual page maps to.")
+DEF_REG_FIELD(PTE_C,
+    "C", 24, 4,
+    "Cacheability attributes for the page.")
+DEF_REG_FIELD(PTE_U,
+    "U", 28, 1,
+    "User mode permitted.")
+DEF_REG_FIELD(PTE_R,
+    "R", 29, 1,
+    "Read-enable.")
+DEF_REG_FIELD(PTE_W,
+    "W", 30, 1,
+    "Write-enable.")
+DEF_REG_FIELD(PTE_X,
+    "X", 31, 1,
+    "Execute-enable.")
+DEF_REG_FIELD(PTE_VPN,
+    "VPN", 32, 20,
+    "Virtual page number that is matched against the load or store address.")
+DEF_REG_FIELD(PTE_ASID,
+    "ASID", 52, 7,
+    "7-bit address space identifier (tag extender)")
+DEF_REG_FIELD(PTE_ATR0,
+    "ATR0", 59, 1,
+    "General purpose attribute bit kept as an attribute of each cache line.")
+DEF_REG_FIELD(PTE_ATR1,
+    "ATR1", 60, 1,
+    "General purpose attribute bit kept as an attribute of each cache line.")
+DEF_REG_FIELD(PTE_PA35,
+    "PA35", 61, 1,
+    "The Extra Physical bit is the most-significant physical address bit.")
+DEF_REG_FIELD(PTE_G,
+    "G", 62, 1,
+    "Global bit. If set, then the ASID is ignored in the match.")
+DEF_REG_FIELD(PTE_V,
+    "V", 63, 1,
+    "Valid bit. indicates whether this entry should be used for matching.")
+
+/* SSR fields */
+DEF_REG_FIELD(SSR_CAUSE,
+    "cause", 0, 8,
+    "8-bit field that contains the reason for various exception.")
+DEF_REG_FIELD(SSR_ASID,
+    "asid", 8, 7,
+    "7-bit field that contains the Address Space Identifier.")
+DEF_REG_FIELD(SSR_UM,
+    "um", 16, 1,
+    "read-write bit.")
+DEF_REG_FIELD(SSR_EX,
+    "ex", 17, 1,
+    "set when an interrupt or exception is accepted.")
+DEF_REG_FIELD(SSR_IE,
+    "ie", 18, 1,
+    "indicates whether the global interrupt is enabled.")
+DEF_REG_FIELD(SSR_GM,
+    "gm", 19, 1,
+    "Guest mode bit.")
+DEF_REG_FIELD(SSR_V0,
+    "v0", 20, 1,
+    "if BADVA0 register contents are from a valid slot 0 instruction.")
+DEF_REG_FIELD(SSR_V1,
+     "v1", 21, 1,
+    "if BADVA1 register contents are from a valid slot 1 instruction.")
+DEF_REG_FIELD(SSR_BVS,
+    "bvs", 22, 1,
+    "BADVA Selector.")
+DEF_REG_FIELD(SSR_CE,
+    "ce", 23, 1,
+    "grants user or guest read permissions to the PCYCLE register aliases.")
+DEF_REG_FIELD(SSR_PE,
+    "pe", 24, 1,
+    "grants guest read permissions to the PMU register aliases.")
+DEF_REG_FIELD(SSR_BP,
+    "bp", 25, 1,
+    "Internal Bus Priority bit.")
+DEF_REG_FIELD(SSR_XA,
+    "xa", 27, 3,
+    "Extension Active, which control operation of an attached coprocessor.")
+DEF_REG_FIELD(SSR_SS,
+    "ss", 30, 1,
+    "Single Step, which enables single-step exceptions.")
+DEF_REG_FIELD(SSR_XE,
+    "xe", 31, 1,
+    "Coprocessor Enable, which enables use of an attached coprocessor.")

--- a/tests/tcg/hexagon/system/standalone_hw.c
+++ b/tests/tcg/hexagon/system/standalone_hw.c
@@ -1,0 +1,43 @@
+#include <stdio.h>
+#include <assert.h>
+
+extern void test_set_prio();
+
+void inst_test()
+{
+    asm volatile("dczeroa(r0)\n\t"
+                 "dccleanidx(r0)\n\t"
+                 "dcinvidx(r0)\n\t"
+                 "r1 = dctagr(r0)\n\t"
+                 "dctagw(r0, r1)\n\t"
+                 "dcfetch(r0)\n\t"
+                 "dccleaninvidx(r0)\n\t"
+                 "l2gclean\n\t"
+                 "l2gclean(r1:0)\n\t"
+                 "l2gcleaninv\n\t"
+                 "l2gcleaninv(r1:0)\n\t"
+                 "l2gunlock\n\t"
+                 "l2kill\n\t"
+                 "trace(r0)\n\t"
+                 "pause(#1)\n\t"
+                );
+
+    asm volatile("r0 = #0\n\t"
+                 "r1 = iassignr(r0)\n\t"
+                 /* Set interrupt 0 to disabled on all threads */
+                 "r0 = #0\n\t"
+                 "iassignw(r0)\n\t");
+
+    test_set_prio();
+    printf("Executed monitor mode instructions\n");
+}
+
+int main(int argc, const char *argv[])
+{
+    inst_test();
+    printf("Hello, World: (argc: %d)\n", argc);
+    assert(argc >= 1);
+    for (int i = 0; i < argc; i++) {
+        printf("\t> '%s'\n", argv[i]);
+    }
+}

--- a/tests/tcg/hexagon/system/standalone_vec.c
+++ b/tests/tcg/hexagon/system/standalone_vec.c
@@ -1,0 +1,1419 @@
+/*
+ *  Copyright(c) 2023-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <hexagon_types.h>
+#include <hexagon_protos.h>
+
+#include "cfgtable.h"
+
+int err;
+
+#ifdef __linux__
+#define VTCM_SIZE_KB (2048)
+#define VTCM_BYTES_PER_KB (1024)
+
+static char vtcm_buffer[VTCM_SIZE_KB * VTCM_BYTES_PER_KB]
+    __attribute__((aligned(0x10000)));
+#endif
+
+/* define the number of rows/cols in a square matrix */
+#define MATRIX_SIZE 64
+
+/* define the size of the scatter buffer */
+#define SCATTER_BUFFER_SIZE (MATRIX_SIZE * MATRIX_SIZE)
+
+#define SCATTER16_BUF_SIZE (2 * SCATTER_BUFFER_SIZE)
+#define SCATTER32_BUF_SIZE (4 * SCATTER_BUFFER_SIZE)
+
+#define GATHER16_BUF_SIZE (2 * MATRIX_SIZE)
+#define GATHER32_BUF_SIZE (4 * MATRIX_SIZE)
+
+uintptr_t VTCM_BASE_ADDRESS;
+uintptr_t VTCM_SCATTER16_ADDRESS;
+uintptr_t VTCM_GATHER16_ADDRESS;
+uintptr_t VTCM_SCATTER32_ADDRESS;
+uintptr_t VTCM_GATHER32_ADDRESS;
+uintptr_t VTCM_SCATTER16_32_ADDRESS;
+uintptr_t VTCM_GATHER16_32_ADDRESS;
+
+/* the vtcm base address */
+unsigned char *vtcm_base;
+
+/* scatter gather 16 bit elements using 16 bit offsets */
+unsigned short *vscatter16;
+unsigned short *vgather16;
+unsigned short vscatter16_ref[SCATTER_BUFFER_SIZE];
+unsigned short vgather16_ref[MATRIX_SIZE];
+
+/* scatter gather 32 bit elements using 32 bit offsets */
+unsigned int *vscatter32;
+unsigned int *vgather32;
+unsigned int vscatter32_ref[SCATTER_BUFFER_SIZE];
+unsigned int vgather32_ref[MATRIX_SIZE];
+
+/* scatter gather 16 bit elements using 32 bit offsets */
+unsigned short *vscatter16_32;
+unsigned short *vgather16_32;
+unsigned short vscatter16_32_ref[SCATTER_BUFFER_SIZE];
+unsigned short vgather16_32_ref[MATRIX_SIZE];
+
+
+/* declare the arrays of offsets */
+unsigned short half_offsets[MATRIX_SIZE];
+unsigned int word_offsets[MATRIX_SIZE];
+
+/* declare the arrays of values */
+unsigned short half_values[MATRIX_SIZE];
+unsigned short half_acc_values[MATRIX_SIZE];
+unsigned short half_q_values[MATRIX_SIZE];
+unsigned int word_values[MATRIX_SIZE];
+unsigned int word_acc_values[MATRIX_SIZE];
+unsigned int word_q_values[MATRIX_SIZE];
+
+/* declare the array of predicates */
+unsigned short half_predicates[MATRIX_SIZE];
+unsigned int word_predicates[MATRIX_SIZE];
+
+/* make this big enough for all the intrinsics */
+unsigned int region_len = 4 * SCATTER_BUFFER_SIZE - 1;
+
+/* optionally add sync instructions */
+#define SYNC_VECTOR 1
+
+/* optionally print cycle counts */
+#define PRINT_CYCLE_COUNTS 0
+
+#if PRINT_CYCLE_COUNTS
+unsigned long long start_cycles;
+#define START_CYCLES start_cycles = hexagon_sim_read_pcycles();
+#define PRINT_CYCLES(x) printf(x, hexagon_sim_read_pcycles() - start_cycles);
+#else
+#define START_CYCLES
+#define PRINT_CYCLES(x)
+#endif
+
+/* define a scratch area for debug and prefill */
+#define SCRATCH_SIZE 0x8800
+
+#define FILL_CHAR '.'
+
+/* fill vtcm scratch with ee */
+void prefill_vtcm_scratch(void)
+{
+    memset((void *)VTCM_BASE_ADDRESS, FILL_CHAR, SCRATCH_SIZE * sizeof(char));
+}
+
+/* print vtcm scratch buffer */
+void print_vtcm_scratch_16(void)
+{
+    unsigned short *vtmp = (unsigned short *)VTCM_BASE_ADDRESS;
+
+    printf("\n\nPrinting the vtcm scratch in half words");
+
+    for (int i = 0; i < SCRATCH_SIZE; i++) {
+        if ((i % MATRIX_SIZE) == 0) {
+            printf("\n");
+        }
+        for (int j = 0; j < 2; j++) {
+            printf("%c", (char)((vtmp[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+}
+
+/* print vtcm scratch buffer */
+void print_vtcm_scratch_32(void)
+{
+    unsigned int *vtmp = (unsigned int *)VTCM_BASE_ADDRESS;
+
+    printf("\n\nPrinting the vtcm scratch in words");
+
+    for (int i = 0; i < SCRATCH_SIZE; i++) {
+        if ((i % MATRIX_SIZE) == 0) {
+            printf("\n");
+        }
+        for (int j = 0; j < 4; j++) {
+            printf("%c", (char)((vtmp[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+}
+
+
+/* create byte offsets to be a diagonal of the matrix with 16 bit elements */
+void create_offsets_and_values_16(void)
+{
+    unsigned short half_element = 0;
+    unsigned short half_q_element = 0;
+    char letter = 'A';
+    char q_letter = '@';
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        half_offsets[i] = i * (2 * MATRIX_SIZE + 2);
+
+        half_element = 0;
+        half_q_element = 0;
+        for (int j = 0; j < 2; j++) {
+            half_element |= letter << j * 8;
+            half_q_element |= q_letter << j * 8;
+        }
+
+        half_values[i] = half_element;
+        half_acc_values[i] = ((i % 10) << 8) + (i % 10);
+        half_q_values[i] = half_q_element;
+
+        letter++;
+        /* reset to 'A' */
+        if (letter == 'M') {
+            letter = 'A';
+        }
+    }
+}
+
+/* create a predicate mask for the half word scatter */
+void create_preds_16()
+{
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        half_predicates[i] = (i % 3 == 0 || i % 5 == 0) ? ~0 : 0;
+    }
+}
+
+
+/* create byte offsets to be a diagonal of the matrix with 32 bit elements */
+void create_offsets_and_values_32(void)
+{
+    unsigned int word_element = 0;
+    unsigned int word_q_element = 0;
+    char letter = 'A';
+    char q_letter = '&';
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        word_offsets[i] = i * (4 * MATRIX_SIZE + 4);
+
+        word_element = 0;
+        word_q_element = 0;
+        for (int j = 0; j < 4; j++) {
+            word_element |= letter << j * 8;
+            word_q_element |= q_letter << j * 8;
+        }
+
+        word_values[i] = word_element;
+        word_acc_values[i] = ((i % 10) << 8) + (i % 10);
+        word_q_values[i] = word_q_element;
+
+        letter++;
+        /* reset to 'A' */
+        if (letter == 'M') {
+            letter = 'A';
+        }
+    }
+}
+
+/* create a predicate mask for the word scatter */
+void create_preds_32()
+{
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        word_predicates[i] = (i % 4 == 0 || i % 7 == 0) ? ~0 : 0;
+    }
+}
+
+
+void dump_buf(char *str, void *addr, int element_size, int byte_len)
+
+{
+    unsigned short *sptr = addr;
+    unsigned int *ptr = addr;
+
+    printf("\n\nBuffer: %s\n", str);
+    for (int i = 0; i < byte_len / element_size; ++ptr, ++sptr, ++i) {
+        if (i != 0 && (i % 16) == 0) {
+            printf("\n");
+        }
+        if (element_size == 2) {
+            printf("%c ", *sptr);
+        } else if (element_size == 4) {
+            printf("%4.4x ", *ptr);
+        }
+    }
+}
+
+/*
+ * create byte offsets to be a diagonal of the matrix with 16 bit elements and
+ * 32 bit offsets
+ */
+void create_offsets_and_values_16_32(void)
+{
+    unsigned int half_element = 0;
+    unsigned short half_q_element = 0;
+    char letter = 'D';
+    char q_letter = '$';
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        word_offsets[i] = i * (2 * MATRIX_SIZE + 2);
+
+        half_element = 0;
+        half_q_element = 0;
+        for (int j = 0; j < 2; j++) {
+            half_element |= letter << j * 8;
+            half_q_element |= q_letter << j * 8;
+        }
+
+        half_values[i] = half_element;
+        half_acc_values[i] = ((i % 10) << 8) + (i % 10);
+        half_q_values[i] = half_q_element;
+
+        letter++;
+        /* reset to 'A' */
+        if (letter == 'P') {
+            letter = 'D';
+        }
+    }
+
+    /*
+     * dump_buf("word_offsets", word_offsets, sizeof(*word_offsets),
+     * sizeof(word_offsets)); dump_buf("half_offsets", half_offsets,
+     * sizeof(*half_offsets), sizeof(half_offsets));
+     */
+}
+
+void create_preds_16_32()
+{
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        half_predicates[i] = (i % 2 == 0 || i % 13 == 0) ? ~0 : 0;
+    }
+}
+
+#define SCATTER_RELEASE(ADDR) \
+    asm volatile("vmem(%0 + #0):scatter_release\n" : : "r"(ADDR));
+
+/* scatter the 16 bit elements using intrinsics */
+void vector_scatter_16(void)
+{
+    START_CYCLES;
+
+    /* copy the offsets and values to vectors */
+    HVX_Vector offsets = *(HVX_Vector *)half_offsets;
+    HVX_Vector values = *(HVX_Vector *)half_values;
+
+    /* do the scatter */
+    Q6_vscatter_RMVhV(VTCM_SCATTER16_ADDRESS, region_len, offsets, values);
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter16);
+    /*
+     * This dummy load from vscatter16 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter16;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter 16 cycles = %llu\n");
+}
+
+/* scatter-accumulate the 16 bit elements using intrinsics */
+void vector_scatter_acc_16(void)
+{
+    START_CYCLES;
+
+    /* copy the offsets and values to vectors */
+    HVX_Vector offsets = *(HVX_Vector *)half_offsets;
+    HVX_Vector values = *(HVX_Vector *)half_acc_values;
+
+    /* do the scatter */
+    Q6_vscatteracc_RMVhV(VTCM_SCATTER16_ADDRESS, region_len, offsets, values);
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter16);
+    /*
+     * This dummy load from vscatter16 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter16;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter Acc 16 cycles = %llu\n");
+}
+
+/* scatter the 16 bit elements using intrinsics */
+void vector_scatter_q_16(void)
+{
+    START_CYCLES;
+
+    /* copy the offsets and values to vectors */
+    HVX_Vector offsets = *(HVX_Vector *)half_offsets;
+    HVX_Vector values = *(HVX_Vector *)half_q_values;
+    HVX_Vector pred_reg = *(HVX_Vector *)half_predicates;
+    HVX_VectorPred preds = Q6_Q_vand_VR(pred_reg, ~0);
+
+    /* do the scatter */
+    Q6_vscatter_QRMVhV(preds, VTCM_SCATTER16_ADDRESS, region_len, offsets,
+                       values);
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter16);
+    /*
+     * This dummy load from vscatter16 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter16;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter Q 16 cycles = %llu\n");
+}
+
+/* scatter the 32 bit elements using intrinsics */
+void vector_scatter_32(void)
+{
+    START_CYCLES;
+
+    /* copy the offsets and values to vectors */
+    HVX_Vector offsetslo = *(HVX_Vector *)word_offsets;
+    HVX_Vector offsetshi = *(HVX_Vector *)&word_offsets[MATRIX_SIZE / 2];
+    HVX_Vector valueslo = *(HVX_Vector *)word_values;
+    HVX_Vector valueshi = *(HVX_Vector *)&word_values[MATRIX_SIZE / 2];
+
+    /* do the scatter */
+    Q6_vscatter_RMVwV(VTCM_SCATTER32_ADDRESS, region_len, offsetslo, valueslo);
+    Q6_vscatter_RMVwV(VTCM_SCATTER32_ADDRESS, region_len, offsetshi, valueshi);
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter32);
+    /*
+     * This dummy load from vscatter32 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter32;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter 32 cycles = %llu\n");
+}
+
+/* scatter-acc the 32 bit elements using intrinsics */
+void vector_scatter_acc_32(void)
+{
+    START_CYCLES;
+
+    /* copy the offsets and values to vectors */
+    HVX_Vector offsetslo = *(HVX_Vector *)word_offsets;
+    HVX_Vector offsetshi = *(HVX_Vector *)&word_offsets[MATRIX_SIZE / 2];
+    HVX_Vector valueslo = *(HVX_Vector *)word_acc_values;
+    HVX_Vector valueshi = *(HVX_Vector *)&word_acc_values[MATRIX_SIZE / 2];
+
+    /* do the scatter */
+    Q6_vscatteracc_RMVwV(VTCM_SCATTER32_ADDRESS, region_len, offsetslo,
+                         valueslo);
+    Q6_vscatteracc_RMVwV(VTCM_SCATTER32_ADDRESS, region_len, offsetshi,
+                         valueshi);
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter32);
+    /*
+     * This dummy load from vscatter32 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter32;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter Acc 32 cycles = %llu\n");
+}
+
+/* scatter the 32 bit elements using intrinsics */
+void vector_scatter_q_32(void)
+{
+    START_CYCLES;
+
+    /* copy the offsets and values to vectors */
+    HVX_Vector offsetslo = *(HVX_Vector *)word_offsets;
+    HVX_Vector offsetshi = *(HVX_Vector *)&word_offsets[MATRIX_SIZE / 2];
+    HVX_Vector valueslo = *(HVX_Vector *)word_q_values;
+    HVX_Vector valueshi = *(HVX_Vector *)&word_q_values[MATRIX_SIZE / 2];
+    HVX_Vector pred_reglo = *(HVX_Vector *)word_predicates;
+    HVX_Vector pred_reghi = *(HVX_Vector *)&word_predicates[MATRIX_SIZE / 2];
+    HVX_VectorPred predslo = Q6_Q_vand_VR(pred_reglo, ~0);
+    HVX_VectorPred predshi = Q6_Q_vand_VR(pred_reghi, ~0);
+
+    /* do the scatter */
+    Q6_vscatter_QRMVwV(predslo, VTCM_SCATTER32_ADDRESS, region_len, offsetslo,
+                       valueslo);
+    Q6_vscatter_QRMVwV(predshi, VTCM_SCATTER32_ADDRESS, region_len, offsetshi,
+                       valueshi);
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter16);
+    /*
+     * This dummy load from vscatter16 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter16;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter Q 16 cycles = %llu\n");
+}
+
+void print_vector(char *str, HVX_Vector *v)
+
+{
+    unsigned char *ptr = (unsigned char *)v;
+
+    printf("\n\nVector: %s\n", str);
+    for (int i = 0; i < sizeof(HVX_Vector) * 4; ++ptr, ++i) {
+        if (i != 0 && (i % 16) == 0) {
+            printf("\n");
+        }
+        printf("%c ", *ptr);
+    }
+    printf("\n");
+}
+
+void print_vectorpair(char *str, HVX_VectorPair *v)
+
+{
+    unsigned char *ptr = (unsigned char *)v;
+
+    printf("\n\nVectorPair: %s\n", str);
+    for (int i = 0; i < sizeof(HVX_VectorPair); ++ptr, ++i) {
+        if (i != 0 && (i % 16) == 0) {
+            printf("\n");
+        }
+        printf("%c ", *ptr);
+    }
+    printf("\n");
+}
+
+/* scatter the 16 bit elements with 32 bit offsets using intrinsics */
+void vector_scatter_16_32(void)
+{
+    START_CYCLES;
+
+    /* get the word offsets in a vector pair */
+    HVX_VectorPair offsets = *(HVX_VectorPair *)word_offsets;
+    /* print_vectorpair("word_offsets", (HVX_VectorPair *)&word_offsets); */
+
+    /* these values need to be shuffled for the RMWwV scatter */
+    HVX_Vector values = *(HVX_Vector *)half_values;
+    values = Q6_Vh_vshuff_Vh(values);
+    /* print_vector("values", (HVX_Vector *)&values); */
+
+    /* do the scatter */
+    Q6_vscatter_RMWwV(VTCM_SCATTER16_32_ADDRESS, region_len, offsets, values);
+    /* print_vector("scatter16_32_address", (HVX_Vector */
+    /* *)VTCM_SCATTER16_32_ADDRESS); */
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter16_32);
+    /*
+     * This dummy load from vscatter16_32 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter16_32;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter 16_32 cycles = %llu\n");
+}
+
+/* scatter-acc the 16 bit elements with 32 bit offsets using intrinsics */
+void vector_scatter_acc_16_32(void)
+{
+    START_CYCLES;
+
+    /* get the word offsets in a vector pair */
+    HVX_VectorPair offsets = *(HVX_VectorPair *)word_offsets;
+    /* print_vectorpair("word_offsets", (HVX_VectorPair *)&word_offsets); */
+
+    /* these values need to be shuffled for the RMWwV scatter */
+    HVX_Vector values = *(HVX_Vector *)half_acc_values;
+    values = Q6_Vh_vshuff_Vh(values);
+    /* print_vector("values", (HVX_Vector *)&values); */
+
+    /* do the scatter */
+    Q6_vscatteracc_RMWwV(VTCM_SCATTER16_32_ADDRESS, region_len, offsets,
+                         values);
+    /* print_vector("scatter16_32_address", (HVX_Vector */
+    /* *)VTCM_SCATTER16_32_ADDRESS); */
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter16_32);
+    /*
+     * This dummy load from vscatter16_32 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter16_32;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter Acc 16_32 cycles = %llu\n");
+}
+
+/* scatter-acc the 16 bit elements with 32 bit offsets using intrinsics */
+void vector_scatter_q_16_32(void)
+{
+    START_CYCLES;
+
+    /* get the word offsets in a vector pair */
+    HVX_VectorPair offsets = *(HVX_VectorPair *)word_offsets;
+    /* print_vectorpair("word_offsets", (HVX_VectorPair *)&word_offsets); */
+
+    /* these values need to be shuffled for the RMWwV scatter */
+    HVX_Vector values = *(HVX_Vector *)half_q_values;
+    values = Q6_Vh_vshuff_Vh(values);
+    /* print_vector("values", (HVX_Vector *)&values); */
+
+    HVX_Vector pred_reg = *(HVX_Vector *)half_predicates;
+    pred_reg = Q6_Vh_vshuff_Vh(pred_reg);
+    HVX_VectorPred preds = Q6_Q_vand_VR(pred_reg, ~0);
+
+    /* do the scatter */
+    Q6_vscatter_QRMWwV(preds, VTCM_SCATTER16_32_ADDRESS, region_len, offsets,
+                       values);
+    /* print_vector("scatter16_32_address", (HVX_Vector */
+    /* *)VTCM_SCATTER16_32_ADDRESS); */
+
+#if SYNC_VECTOR
+    /* do the sync operation */
+    SCATTER_RELEASE(vscatter16_32);
+    /*
+     * This dummy load from vscatter16_32 is to complete the synchronization.
+     * Normally this load would be deferred as long as possible to minimize
+     * stalls.
+     */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vscatter16_32;
+#endif
+
+    PRINT_CYCLES("\nVector Scatter Q 16_32 cycles = %llu\n");
+}
+
+
+/* gather the elements from the scatter16 buffer */
+void vector_gather_16(void)
+{
+    START_CYCLES;
+
+    HVX_Vector *vgather = (HVX_Vector *)VTCM_GATHER16_ADDRESS;
+    HVX_Vector offsets = *(HVX_Vector *)half_offsets;
+
+    /* do the gather to the gather16 buffer */
+    Q6_vgather_ARMVh(vgather, VTCM_SCATTER16_ADDRESS, region_len, offsets);
+
+
+#if SYNC_VECTOR
+    /* This dummy read of vgather will stall until completion */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vgather;
+#endif
+
+    PRINT_CYCLES("\nVector Gather 16 cycles = %llu\n");
+}
+
+static unsigned short gather_q_16_init(void)
+{
+    char letter = '?';
+    return letter | (letter << 8);
+}
+
+void vector_gather_q_16(void)
+{
+    START_CYCLES;
+
+    HVX_Vector *vgather = (HVX_Vector *)VTCM_GATHER16_ADDRESS;
+    HVX_Vector offsets = *(HVX_Vector *)half_offsets;
+    HVX_Vector pred_reg = *(HVX_Vector *)half_predicates;
+    HVX_VectorPred preds = Q6_Q_vand_VR(pred_reg, ~0);
+
+    *vgather = Q6_Vh_vsplat_R(gather_q_16_init());
+    /* do the gather to the gather16 buffer */
+    Q6_vgather_AQRMVh(vgather, preds, VTCM_SCATTER16_ADDRESS, region_len,
+                      offsets);
+
+
+#if SYNC_VECTOR
+    /* This dummy read of vgather will stall until completion */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vgather;
+#endif
+
+    PRINT_CYCLES("\nVector Gather Q 16 cycles = %llu\n");
+}
+
+
+/* gather the elements from the scatter32 buffer */
+void vector_gather_32(void)
+{
+    START_CYCLES;
+
+    HVX_Vector *vgatherlo = (HVX_Vector *)VTCM_GATHER32_ADDRESS;
+    HVX_Vector *vgatherhi =
+        (HVX_Vector *)(VTCM_GATHER32_ADDRESS + (MATRIX_SIZE * 2));
+    HVX_Vector offsetslo = *(HVX_Vector *)word_offsets;
+    HVX_Vector offsetshi = *(HVX_Vector *)&word_offsets[MATRIX_SIZE / 2];
+
+    /* do the gather to vgather */
+    Q6_vgather_ARMVw(vgatherlo, VTCM_SCATTER32_ADDRESS, region_len, offsetslo);
+    Q6_vgather_ARMVw(vgatherhi, VTCM_SCATTER32_ADDRESS, region_len, offsetshi);
+
+#if SYNC_VECTOR
+    /* This dummy read of vgatherhi will stall until completion */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vgatherhi;
+#endif
+
+    PRINT_CYCLES("\nVector Gather 32 cycles = %llu\n");
+}
+
+static unsigned int gather_q_32_init(void)
+{
+    char letter = '?';
+    return letter | (letter << 8) | (letter << 16) | (letter << 24);
+}
+
+void vector_gather_q_32(void)
+{
+    START_CYCLES;
+
+    HVX_Vector *vgatherlo = (HVX_Vector *)VTCM_GATHER32_ADDRESS;
+    HVX_Vector *vgatherhi =
+        (HVX_Vector *)(VTCM_GATHER32_ADDRESS + (MATRIX_SIZE * 2));
+    HVX_Vector offsetslo = *(HVX_Vector *)word_offsets;
+    HVX_Vector offsetshi = *(HVX_Vector *)&word_offsets[MATRIX_SIZE / 2];
+    HVX_Vector pred_reglo = *(HVX_Vector *)word_predicates;
+    HVX_VectorPred predslo = Q6_Q_vand_VR(pred_reglo, ~0);
+    HVX_Vector pred_reghi = *(HVX_Vector *)&word_predicates[MATRIX_SIZE / 2];
+    HVX_VectorPred predshi = Q6_Q_vand_VR(pred_reghi, ~0);
+
+    *vgatherlo = Q6_Vh_vsplat_R(gather_q_32_init());
+    *vgatherhi = Q6_Vh_vsplat_R(gather_q_32_init());
+    /* do the gather to vgather */
+    Q6_vgather_AQRMVw(vgatherlo, predslo, VTCM_SCATTER32_ADDRESS, region_len,
+                      offsetslo);
+    Q6_vgather_AQRMVw(vgatherhi, predshi, VTCM_SCATTER32_ADDRESS, region_len,
+                      offsetshi);
+
+#if SYNC_VECTOR
+    /* This dummy read of vgatherhi will stall until completion */
+    volatile HVX_Vector vDummy = *(HVX_Vector *)vgatherhi;
+#endif
+
+    PRINT_CYCLES("\nVector Gather Q 32 cycles = %llu\n");
+}
+
+/* gather the elements from the scatter16_32 buffer */
+void vector_gather_16_32(void)
+{
+    START_CYCLES;
+
+    /* get the vtcm address to gather from */
+    HVX_Vector *vgather = (HVX_Vector *)VTCM_GATHER16_32_ADDRESS;
+
+    /* get the word offsets in a vector pair */
+    HVX_VectorPair offsets = *(HVX_VectorPair *)word_offsets;
+
+    /* do the gather to vgather */
+    Q6_vgather_ARMWw(vgather, VTCM_SCATTER16_32_ADDRESS, region_len, offsets);
+
+    /* the read of gather will stall until completion */
+    volatile HVX_Vector values = *(HVX_Vector *)vgather;
+
+    /* deal the elements to get the order back */
+    values = Q6_Vh_vdeal_Vh(values);
+
+    /* write it back to vtcm address */
+    *(HVX_Vector *)vgather = values;
+
+
+    PRINT_CYCLES("\nVector Gather 16_32 cycles = %llu\n");
+}
+
+void vector_gather_q_16_32(void)
+{
+    START_CYCLES;
+
+    /* get the vtcm address to gather from */
+    HVX_Vector *vgather = (HVX_Vector *)VTCM_GATHER16_32_ADDRESS;
+
+    /* get the word offsets in a vector pair */
+    HVX_VectorPair offsets = *(HVX_VectorPair *)word_offsets;
+    HVX_Vector pred_reg = *(HVX_Vector *)half_predicates;
+    pred_reg = Q6_Vh_vshuff_Vh(pred_reg);
+    HVX_VectorPred preds = Q6_Q_vand_VR(pred_reg, ~0);
+
+    *vgather = Q6_Vh_vsplat_R(gather_q_16_init());
+    /* do the gather to vgather */
+    Q6_vgather_AQRMWw(vgather, preds, VTCM_SCATTER16_32_ADDRESS, region_len,
+                      offsets);
+
+    /* the read of gather will stall until completion */
+    volatile HVX_Vector values = *(HVX_Vector *)vgather;
+
+    /* deal the elements to get the order back */
+    values = Q6_Vh_vdeal_Vh(values);
+
+    /* write it back to vtcm address */
+    *(HVX_Vector *)vgather = values;
+
+
+    PRINT_CYCLES("\nVector Gather Q 16_32 cycles = %llu\n");
+}
+
+
+static void check_buffer(const char *name, void *c, void *r, size_t size)
+{
+    char *check = (char *)c;
+    char *ref = (char *)r;
+    /*  printf("check buffer %s 0x%x, 0x%x, %d\n", name, check, ref, size); */
+    for (int i = 0; i < size; i++) {
+        if (check[i] != ref[i]) {
+            printf("Error %s [%d]: 0x%x (%c) != 0x%x (%c)\n", name, i, check[i],
+                   check[i], ref[i], ref[i]);
+            err++;
+        }
+    }
+}
+
+
+/*
+ * These scalar functions are the C equivalents of the vector functions that
+ * use HVX
+ */
+
+/* scatter the 16 bit elements using C */
+void scalar_scatter_16(unsigned short *vscatter16)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vscatter16[half_offsets[i] / 2] = half_values[i];
+    }
+
+    PRINT_CYCLES("\nScalar Scatter 16 cycles = %llu\n");
+}
+
+void check_scatter_16()
+{
+    memset(vscatter16_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+    scalar_scatter_16(vscatter16_ref);
+    check_buffer("check_scatter_16", vscatter16, vscatter16_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+}
+
+/* scatter the 16 bit elements using C */
+void scalar_scatter_acc_16(unsigned short *vscatter16)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vscatter16[half_offsets[i] / 2] += half_acc_values[i];
+    }
+
+    PRINT_CYCLES("\nScalar Scatter Acc 16 cycles = %llu\n");
+}
+
+/* scatter the 16 bit elements using C */
+void scalar_scatter_q_16(unsigned short *vscatter16)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        if (half_predicates[i]) {
+            vscatter16[half_offsets[i] / 2] = half_q_values[i];
+        }
+    }
+
+    PRINT_CYCLES("\nScalar Scatter Q 16 cycles = %llu\n");
+}
+
+
+void check_scatter_acc_16()
+{
+    memset(vscatter16_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+    scalar_scatter_16(vscatter16_ref);
+    scalar_scatter_acc_16(vscatter16_ref);
+    check_buffer("check_scatter_acc_16", vscatter16, vscatter16_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+}
+
+void check_scatter_q_16()
+{
+    memset(vscatter16_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+    scalar_scatter_16(vscatter16_ref);
+    scalar_scatter_acc_16(vscatter16_ref);
+    scalar_scatter_q_16(vscatter16_ref);
+    check_buffer("check_scatter_q_16", vscatter16, vscatter16_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+}
+
+/* scatter the 32 bit elements using C */
+void scalar_scatter_32(unsigned int *vscatter32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vscatter32[word_offsets[i] / 4] = word_values[i];
+    }
+
+    PRINT_CYCLES("\n\nScalar Scatter 32 cycles = %llu\n");
+}
+
+/* scatter the 32 bit elements using C */
+void scalar_scatter_acc_32(unsigned int *vscatter32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vscatter32[word_offsets[i] / 4] += word_acc_values[i];
+    }
+
+    PRINT_CYCLES("\nScalar Scatter Acc 32 cycles = %llu\n");
+}
+
+/* scatter the 32 bit elements using C */
+void scalar_scatter_q_32(unsigned int *vscatter32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        if (word_predicates[i]) {
+            vscatter32[word_offsets[i] / 4] = word_q_values[i];
+        }
+    }
+
+    PRINT_CYCLES("\nScalar Scatter Q 32 cycles = %llu\n");
+}
+
+void check_scatter_32()
+{
+    memset(vscatter32_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned int));
+    scalar_scatter_32(vscatter32_ref);
+    check_buffer("check_scatter_32", vscatter32, vscatter32_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned int));
+}
+
+void check_scatter_acc_32()
+{
+    memset(vscatter32_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned int));
+    scalar_scatter_32(vscatter32_ref);
+    scalar_scatter_acc_32(vscatter32_ref);
+    check_buffer("check_scatter_acc_32", vscatter32, vscatter32_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned int));
+}
+
+void check_scatter_q_32()
+{
+    memset(vscatter32_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned int));
+    scalar_scatter_32(vscatter32_ref);
+    scalar_scatter_acc_32(vscatter32_ref);
+    scalar_scatter_q_32(vscatter32_ref);
+    check_buffer("check_scatter_q_32", vscatter32, vscatter32_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned int));
+}
+
+/* scatter the 32 bit elements using C */
+void scalar_scatter_16_32(unsigned short *vscatter16_32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vscatter16_32[word_offsets[i] / 2] = half_values[i];
+    }
+
+    PRINT_CYCLES("\n\nScalar Scatter 16_32 cycles = %llu\n");
+}
+
+/* scatter the 32 bit elements using C */
+void scalar_scatteracc_16_32(unsigned short *vscatter16_32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vscatter16_32[word_offsets[i] / 2] += half_acc_values[i];
+    }
+
+    PRINT_CYCLES("\n\nScalar Scatter Acc 16_32 cycles = %llu\n");
+}
+
+void scalar_scatter_q_16_32(unsigned short *vscatter16_32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        if (half_predicates[i]) {
+            vscatter16_32[word_offsets[i] / 2] = half_q_values[i];
+        }
+    }
+
+    PRINT_CYCLES("\nScalar Scatter Q 16_32 cycles = %llu\n");
+}
+
+void check_scatter_16_32()
+{
+    memset(vscatter16_32_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+    scalar_scatter_16_32(vscatter16_32_ref);
+    check_buffer("check_scatter_16_32", vscatter16_32, vscatter16_32_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+}
+
+void check_scatter_acc_16_32()
+{
+    memset(vscatter16_32_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+    scalar_scatter_16_32(vscatter16_32_ref);
+    scalar_scatteracc_16_32(vscatter16_32_ref);
+    check_buffer("check_scatter_acc_16_32", vscatter16_32, vscatter16_32_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+}
+
+void check_scatter_q_16_32()
+{
+    memset(vscatter16_32_ref, FILL_CHAR,
+           SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+    scalar_scatter_16_32(vscatter16_32_ref);
+    scalar_scatteracc_16_32(vscatter16_32_ref);
+    scalar_scatter_q_16_32(vscatter16_32_ref);
+    check_buffer("check_scatter_q_16_32", vscatter16_32, vscatter16_32_ref,
+                 SCATTER_BUFFER_SIZE * sizeof(unsigned short));
+}
+
+/* gather the elements from the scatter buffer using C */
+void scalar_gather_16(unsigned short *vgather16)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vgather16[i] = vscatter16[half_offsets[i] / 2];
+    }
+
+    PRINT_CYCLES("\n\nScalar Gather 16 cycles = %llu\n");
+}
+
+void scalar_gather_q_16(unsigned short *vgather16)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        if (half_predicates[i]) {
+            vgather16[i] = vscatter16[half_offsets[i] / 2];
+        }
+    }
+
+    PRINT_CYCLES("\n\nScalar Gather Q 16 cycles = %llu\n");
+}
+
+void check_gather_16()
+{
+    memset(vgather16_ref, 0, MATRIX_SIZE * sizeof(unsigned short));
+    scalar_gather_16(vgather16_ref);
+    check_buffer("check_gather_16", vgather16, vgather16_ref,
+                 MATRIX_SIZE * sizeof(unsigned short));
+}
+
+void check_gather_q_16()
+{
+    memset(vgather16_ref, gather_q_16_init(),
+           MATRIX_SIZE * sizeof(unsigned short));
+    scalar_gather_q_16(vgather16_ref);
+    check_buffer("check_gather_q_16", vgather16, vgather16_ref,
+                 MATRIX_SIZE * sizeof(unsigned short));
+}
+
+/* gather the elements from the scatter buffer using C */
+void scalar_gather_32(unsigned int *vgather32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vgather32[i] = vscatter32[word_offsets[i] / 4];
+    }
+
+    PRINT_CYCLES("\n\nScalar Gather 32 cycles = %llu\n");
+}
+
+void scalar_gather_q_32(unsigned int *vgather32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        if (word_predicates[i]) {
+            vgather32[i] = vscatter32[word_offsets[i] / 4];
+        }
+    }
+
+    PRINT_CYCLES("\n\nScalar Gather Q 32 cycles = %llu\n");
+}
+
+
+void check_gather_32(void)
+{
+    memset(vgather32_ref, 0, MATRIX_SIZE * sizeof(unsigned int));
+    scalar_gather_32(vgather32_ref);
+    check_buffer("check_gather_32", vgather32, vgather32_ref,
+                 MATRIX_SIZE * sizeof(unsigned int));
+}
+
+void check_gather_q_32(void)
+{
+    memset(vgather32_ref, gather_q_32_init(),
+           MATRIX_SIZE * sizeof(unsigned int));
+    scalar_gather_q_32(vgather32_ref);
+    check_buffer("check_gather_q_32", vgather32, vgather32_ref,
+                 MATRIX_SIZE * sizeof(unsigned int));
+}
+
+/* gather the elements from the scatter buffer using C */
+void scalar_gather_16_32(unsigned short *vgather16_32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        vgather16_32[i] = vscatter16_32[word_offsets[i] / 2];
+    }
+
+    PRINT_CYCLES("\n\nScalar Gather 16_32 cycles = %llu\n");
+}
+
+void scalar_gather_q_16_32(unsigned short *vgather16_32)
+{
+    START_CYCLES;
+
+    for (int i = 0; i < MATRIX_SIZE; ++i) {
+        if (half_predicates[i]) {
+            vgather16_32[i] = vscatter16_32[word_offsets[i] / 2];
+        }
+    }
+
+    PRINT_CYCLES("\n\nScalar Gather Q 16_32 cycles = %llu\n");
+}
+
+void check_gather_16_32(void)
+{
+    memset(vgather16_32_ref, 0, MATRIX_SIZE * sizeof(unsigned short));
+    scalar_gather_16_32(vgather16_32_ref);
+    check_buffer("check_gather_16_32", vgather16_32, vgather16_32_ref,
+                 MATRIX_SIZE * sizeof(unsigned short));
+}
+
+void check_gather_q_16_32(void)
+{
+    memset(vgather16_32_ref, gather_q_16_init(),
+           MATRIX_SIZE * sizeof(unsigned short));
+    scalar_gather_q_16_32(vgather16_32_ref);
+    check_buffer("check_gather_q_16_32", vgather16_32, vgather16_32_ref,
+                 MATRIX_SIZE * sizeof(unsigned short));
+}
+
+/* These functions print the buffers to the display */
+
+/* print scatter16 buffer */
+void print_scatter16_buffer(void)
+{
+#if PRINT_DATA
+    /*
+     * printf("\n\nPrinting the 16 bit scatter buffer at 0x%08x",
+     * VTCM_SCATTER16_ADDRESS);
+     */
+    printf("\n\nPrinting the 16 bit scatter buffer");
+
+    for (int i = 0; i < SCATTER_BUFFER_SIZE; i++) {
+        if ((i % MATRIX_SIZE) == 0) {
+            printf("\n");
+        }
+
+        for (int j = 0; j < 2; j++) {
+            printf("%c", (char)((vscatter16[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+    printf("\n");
+#endif
+}
+
+/* print the gather 16 buffer */
+void print_gather_result_16(void)
+{
+#if PRINT_DATA
+    /*
+     * printf("\n\nPrinting the 16 bit gather result at 0x%08x\n",
+     * VTCM_GATHER16_ADDRESS);
+     */
+    printf("\n\nPrinting the 16 bit gather result\n");
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        for (int j = 0; j < 2; j++) {
+            printf("%c", (char)((vgather16[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+    printf("\n");
+#endif
+}
+
+/* print the scatter32 buffer */
+void print_scatter32_buffer(void)
+{
+#if PRINT_DATA
+    /*
+     * printf("\n\nPrinting the 32 bit scatter buffer at 0x%08x",
+     * VTCM_SCATTER32_ADDRESS);
+     */
+    printf("\n\nPrinting the 32 bit scatter buffer");
+
+    for (int i = 0; i < SCATTER_BUFFER_SIZE; i++) {
+        if ((i % MATRIX_SIZE) == 0) {
+            printf("\n");
+        }
+
+        for (int j = 0; j < 4; j++) {
+            printf("%c", (char)((vscatter32[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+    printf("\n");
+#endif
+}
+
+
+/* print the gather 32 buffer */
+void print_gather_result_32(void)
+{
+#if PRINT_DATA
+    /*
+     * printf("\n\nPrinting the 32 bit gather result at 0x%08x\n",
+     * VTCM_GATHER32_ADDRESS);
+     */
+    printf("\n\nPrinting the 32 bit gather result\n");
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        for (int j = 0; j < 4; j++) {
+            printf("%c", (char)((vgather32[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+    printf("\n");
+#endif
+}
+
+/* print the scatter16_32 buffer */
+void print_scatter16_32_buffer(void)
+{
+#if PRINT_DATA
+    /*
+     * printf("\n\nPrinting the 16_32 bit scatter buffer at 0x%08x",
+     * VTCM_SCATTER16_32_ADDRESS);
+     */
+    printf("\n\nPrinting the 16_32 bit scatter buffer");
+
+    for (int i = 0; i < SCATTER_BUFFER_SIZE; i++) {
+        if ((i % MATRIX_SIZE) == 0) {
+            printf("\n");
+        }
+
+        for (int j = 0; j < 2; j++) {
+            printf("%c", (unsigned char)((vscatter16_32[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+    printf("\n");
+#endif
+}
+
+/* print the gather 16_32 buffer */
+void print_gather_result_16_32(void)
+{
+#if PRINT_DATA
+    /*
+     * printf("\n\nPrinting the 16_32 bit gather result at 0x%08x\n",
+     * VTCM_GATHER16_32_ADDRESS);
+     */
+    printf("\n\nPrinting the 16_32 bit gather result\n");
+
+    for (int i = 0; i < MATRIX_SIZE; i++) {
+        for (int j = 0; j < 2; j++) {
+            printf("%c", (unsigned char)((vgather16_32[i] >> j * 8) & 0xff));
+        }
+
+        printf(" ");
+    }
+    printf("\n");
+#endif
+}
+
+/*
+ * set up the tcm address translation
+ * Note: This method is only for the standalone environment
+ * SDK users should use the "VTCM Manager" to use VTCM
+ */
+void setup_tcm(void)
+{
+    VTCM_BASE_ADDRESS = get_vtcm_base();
+
+    uint64_t pa = VTCM_BASE_ADDRESS;
+    void *va = (void *)VTCM_BASE_ADDRESS;
+
+    VTCM_SCATTER16_ADDRESS = VTCM_BASE_ADDRESS;
+    VTCM_GATHER16_ADDRESS = VTCM_BASE_ADDRESS + SCATTER16_BUF_SIZE;
+    VTCM_SCATTER32_ADDRESS = VTCM_GATHER16_ADDRESS + GATHER16_BUF_SIZE;
+    VTCM_GATHER32_ADDRESS = VTCM_SCATTER32_ADDRESS + SCATTER32_BUF_SIZE;
+    VTCM_SCATTER16_32_ADDRESS = VTCM_GATHER32_ADDRESS + GATHER32_BUF_SIZE;
+    VTCM_GATHER16_32_ADDRESS = VTCM_SCATTER16_32_ADDRESS + SCATTER16_BUF_SIZE;
+
+    /* the vtcm base address */
+    vtcm_base = (unsigned char *)VTCM_BASE_ADDRESS;
+
+    /* scatter gather 16 bit elements using 16 bit offsets */
+    vscatter16 = (unsigned short *)VTCM_SCATTER16_ADDRESS;
+    vgather16 = (unsigned short *)VTCM_GATHER16_ADDRESS;
+
+    /* scatter gather 32 bit elements using 32 bit offsets */
+    vscatter32 = (unsigned int *)VTCM_SCATTER32_ADDRESS;
+    vgather32 = (unsigned int *)VTCM_GATHER32_ADDRESS;
+
+    /* scatter gather 16 bit elements using 32 bit offsets */
+    vscatter16_32 = (unsigned short *)VTCM_SCATTER16_32_ADDRESS;
+    vgather16_32 = (unsigned short *)VTCM_GATHER16_32_ADDRESS;
+}
+
+void inst_test()
+{
+    /* Should NOT throw an error when paranoid-commit-state turned on */
+    uint32_t R;
+    asm volatile("release(%0):at\n\t" : : "r"(R));
+}
+
+
+int main()
+{
+    setup_tcm();
+    prefill_vtcm_scratch();
+
+    /* 16 bit elements with 16 bit offsets */
+    create_offsets_and_values_16();
+    create_preds_16();
+
+#if PRINT_CYCLE_COUNTS
+    scalar_scatter_16(vscatter16);
+#endif
+    vector_scatter_16();
+    print_scatter16_buffer();
+    check_scatter_16();
+
+
+#if PRINT_CYCLE_COUNTS
+    scalar_gather_16(vgather16);
+#endif
+    vector_gather_16();
+    print_gather_result_16();
+    check_gather_16();
+
+    vector_gather_q_16();
+    print_gather_result_16();
+    check_gather_q_16();
+
+    vector_scatter_acc_16();
+    print_scatter16_buffer();
+    check_scatter_acc_16();
+
+    vector_scatter_q_16();
+    print_scatter16_buffer();
+    check_scatter_q_16();
+
+    /* 32 bit elements with 32 bit offsets */
+    create_offsets_and_values_32();
+    create_preds_32();
+
+#if PRINT_CYCLE_COUNTS
+    scalar_scatter_32(vscatter32);
+#endif
+
+    vector_scatter_32();
+
+    print_scatter32_buffer();
+    check_scatter_32();
+
+#if PRINT_CYCLE_COUNTS
+    scalar_gather_32(vgather32);
+#endif
+
+    vector_gather_32();
+
+    print_gather_result_32();
+    check_gather_32();
+
+    vector_gather_q_32();
+    print_gather_result_32();
+    check_gather_q_32();
+
+    vector_scatter_acc_32();
+    print_scatter32_buffer();
+    check_scatter_acc_32();
+
+    vector_scatter_q_32();
+    print_scatter32_buffer();
+    check_scatter_q_32();
+
+    /* 16 bit elements with 32 bit offsets */
+    create_offsets_and_values_16_32();
+    create_preds_16_32();
+
+#if PRINT_CYCLE_COUNTS
+    scalar_scatter_16_32();
+#endif
+    vector_scatter_16_32();
+
+    print_scatter16_32_buffer();
+    check_scatter_16_32();
+
+#if PRINT_CYCLE_COUNTS
+    scalar_gather_16_32(vgather16_32);
+#endif
+
+    vector_gather_16_32();
+
+    print_gather_result_16_32();
+    check_gather_16_32();
+
+    vector_gather_q_16_32();
+    print_gather_result_16_32();
+    check_gather_q_16_32();
+
+    vector_scatter_acc_16_32();
+    print_scatter16_32_buffer();
+    check_scatter_acc_16_32();
+
+    vector_scatter_q_16_32();
+    print_scatter16_32_buffer();
+    check_scatter_q_16_32();
+
+    inst_test();
+    printf("%s\n", ((err) ? "FAIL" : "PASS"));
+    return err;
+}

--- a/tests/tcg/hexagon/system/tlb-miss-tlblock.S
+++ b/tests/tcg/hexagon/system/tlb-miss-tlblock.S
@@ -1,0 +1,156 @@
+/*
+ *  Copyright(c) 2019-2025 Qualcomm Innovation Center, Inc. All Rights Reserved.
+ *
+ *  SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+/*
+ * Test Purpose:
+ * Verify that tlbmissx and tlbmissrw do not set the syscfg.tl bit
+ * The HW spec says:
+ *     "TLBLOCK is acquired automatically whenever a hardware thread raises a
+ *      TLB miss-RW or TLBmiss-X exception."
+ * The casual reader would assume that a miss handler would implicitly have
+ * the lock, that apparently
+ * isn't the case.
+ */
+
+.global start
+start:
+    r0 = ##evb
+    evb = r0
+    r0 = ##0
+    ssr = r0
+    jump #setup
+
+#define tlb_index r11
+#define stack r29
+#define data r18
+tlb_index = ##0x00000007
+
+.org 0x100
+
+evb:
+    jump #reset
+    jump #nmi
+    jump #error
+    jump #0
+    jump #tlbmissx
+    jump #0
+    jump #tlbmissrw
+
+
+setup:
+    {
+        r1 = ##0xc009b800
+        r0 = ##0xf7137010
+    }
+    tlb_index = add(tlb_index, #1)
+    tlbw(r1:0,tlb_index)
+
+/* Enable MMU */
+    r2 = ##0x0085a07f
+    syscfg = r2
+
+/* Test setup */
+    r12 = #0x12
+    r0 = #0x6
+    r7 = ##0x77777777
+    r6 = ##0x66666666
+    data = ##0xf2000000
+    stack = ##0x9ba01000
+    jump ##.L_server_loop
+
+/* event vector handlers */
+reset:
+    r2 = #1
+    stop(r0)
+nmi:
+    r2 = #1
+    stop(r0)
+error:
+    r2 = #1
+    stop(r0)
+
+
+/*
+ * Can only handle a single ex fault.
+ */
+tlbmissx:
+  r0 = syscfg
+  r1 = #0x800
+/*
+ * Fail if we automatically start setting SYSCFG:TL again
+ */
+    r0 = and(r0, r1)
+    {
+        p0 = cmp.eq(r0, r1); if (p0.new) jump:t .Lfailmissx
+    }
+    {
+        r1 = ##0xc009b900
+        r0 = ##0xf7137210
+    }
+    tlb_index = add(tlb_index, #1)
+    tlbw(r1:0,tlb_index)
+    tlbunlock
+    rte
+    stop(r0);
+.Lfailmissx:
+    r2 = #1
+    stop(r2);
+
+/*
+ * Can only handle a stack fault and a data fault
+ */
+tlbmissrw:
+    r0 = syscfg
+    r1 = #0x800
+/*
+ * Fail if we automatically start setting SYSCFG:TL again
+ */
+    r0 = and(r0, r1)
+    {
+        p0 = cmp.eq(r0, r1); if (p0.new) jump:t .Lfailmissrw
+    }
+    r0 = badva
+    p0 = cmp.eq (stack, r0) // missed the stack
+    if (!p0) jump .Ldata
+    {
+        r1 = ##0xc009ba00
+        r0 = ##0xf7137210
+    }
+  jump #.Ldone
+.Ldata:
+    {
+        r1 = ##0xc00f2000
+        r0 = ##0xf71e4010
+    }
+.Ldone:
+    tlb_index = add(tlb_index, #1)
+    tlbw(r1:0,tlb_index)
+    tlbunlock
+    rte
+.Lfailmissrw:
+    r2 = #1
+    stop(r2);
+
+
+
+.org 0x100000
+  nop
+.Lpass:
+   r2 = #0
+   stop(r0);
+   trap0(#0x18)
+.L_server_loop:
+{
+    p0 = cmp.eq(r0,#-0x1)
+    if (!p0.new) jump:t .Lpass
+    memd(stack) = r7:6; // S1 store to stack will also fault
+    memw(data) = r12; // S0 store will fault
+}
+/*
+ * We should not get here:
+ */
+   r2 = #1
+   stop(r0);

--- a/tests/tcg/hexagon/system/vid_reg.c
+++ b/tests/tcg/hexagon/system/vid_reg.c
@@ -1,0 +1,36 @@
+/*
+ * Verify vid reads/writes really update the register.
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+
+static inline uint32_t getvid()
+{
+    uint32_t reg;
+    asm volatile("%0=vid;" : "=r"(reg));
+    return reg;
+}
+static inline void setvid(uint32_t val)
+{
+    asm volatile("vid=%0;" : : "r"(val));
+    return;
+}
+int main()
+{
+    uint32_t testval = 0x3ff03ff;
+    setvid(testval);
+    if (testval != getvid()) {
+        printf("ERROR: vid read returned: 0x%x\n", getvid());
+    }
+    assert(testval == getvid());
+
+    /* L2VIC_NO_PENDING (0xffffffff) should not update the vid */
+    setvid(0xffffffff);
+    if (testval != getvid()) {
+        printf("ERROR: vid read returned: 0x%x\n", getvid());
+    }
+
+    assert(testval == getvid());
+}


### PR DESCRIPTION
This MR contains:

- 1 fixup! to be squashed on hex-next
- A few additions/fixes to target/hexagon
- check-tcg tests for sysemu using upstream compiler