### PR TITLE
Fix register write limits.

### DIFF
--- a/target/hexagon/cpu.h
+++ b/target/hexagon/cpu.h
@@ -21,9 +21,9 @@
 #include "fpu/softfloat-types.h"
 
 #define NUM_GREGS 32
-#define GREG_WRITES_MAX 32
+#define GREG_WRITES_MAX 2
 #define NUM_SREGS 64
-#define SREG_WRITES_MAX 64
+#define SREG_WRITES_MAX 2
 
 #include "cpu-qom.h"
 #include "exec/cpu-defs.h"
@@ -40,9 +40,8 @@ typedef struct CPUHexagonTLBContext CPUHexagonTLBContext;
 #define NUM_PREGS 4
 #define TOTAL_PER_THREAD_REGS 64
 
-#define SLOTS_MAX 4
 #define STORES_MAX 2
-#define REG_WRITES_MAX 32
+#define REG_WRITES_MAX 12                   /* 4 pairs + endloop(sa[01], lc[01])*/
 #define PRED_WRITES_MAX 5                   /* 4 insns + endloop */
 #define VSTORES_MAX 2
 #define THREADS_MAX 8

--- a/target/hexagon/max.h
+++ b/target/hexagon/max.h
@@ -6,21 +6,6 @@
 #ifndef HEXAGON_MAX_H
 #define HEXAGON_MAX_H
 
-#define MAX_EXT_CONTEXTS 8
-#define MAX_L2_INTERLEAVES 2
-#define MAX_VFIFO_COUNT 4
-
-#define SLOTS_MAX 4
-
-#define REG_WRITES_MAX 32
-#define PRED_WRITES_MAX 5
-#define STORES_MAX 2
-#define LOADS_MAX 2
-#define MAX_PRED 4
-
-#define PACKET_BYTES_MAX 16
 #define MAX_TLB_ENTRIES 1024
-#define DTLB_ENTRIES 16
-#define ITLB_ENTRIES 16
 
 #endif /* HEXAGON_MAX_H */


### PR DESCRIPTION
Guest and System are at most 2, register pair

General regs are at most 12, 4 pair and sa[01]/lc[01] in the case of an endloop.

Remove some unused #defines.