### PR TITLE
fixup! target/hexagon: Add System/Guest register definitions

### DIFF
--- a/target/hexagon/hex_common.py
+++ b/target/hexagon/hex_common.py
@@ -1074,7 +1074,7 @@ class GuestRegister(Register):
             """))
         else:
             f.write(code_fmt(f"""\
-check_greg_impl(insn->regno[{regno}], {str(self.is_pair()).lower()});
+                check_greg_impl(insn->regno[{regno}], {str(self.is_pair()).lower()});
             """))
 
 class GuestDest(GuestRegister, Single, Dest):
@@ -1083,7 +1083,6 @@ class GuestDest(GuestRegister, Single, Dest):
         self.gen_check_impl(f, regno)
         f.write(code_fmt(f"""\
             TCGv {self.reg_tcg()} = tcg_temp_new();
-            gen_read_greg({self.reg_tcg()}, {self.reg_num});
         """))
     def log_write(self, f, tag):
         f.write(code_fmt(f"""\
@@ -1109,7 +1108,6 @@ class GuestPairDest(GuestRegister, Pair, Dest):
         self.gen_check_impl(f, regno)
         f.write(code_fmt(f"""\
             TCGv_i64 {self.reg_tcg()} = tcg_temp_new_i64();
-            gen_read_greg_pair({self.reg_tcg()}, {self.reg_num});
         """))
     def log_write(self, f, tag):
         f.write(code_fmt(f"""\
@@ -1134,7 +1132,6 @@ class SystemDest(Register, Single, Dest):
         self.decl_reg_num(f, regno)
         f.write(code_fmt(f"""\
             TCGv {self.reg_tcg()} = tcg_temp_new();
-            gen_read_sreg({self.reg_tcg()}, {self.reg_num});
         """))
     def log_write(self, f, tag):
         f.write(code_fmt(f"""\
@@ -1158,7 +1155,6 @@ class SystemPairDest(Register, Pair, Dest):
         self.decl_reg_num(f, regno)
         f.write(code_fmt(f"""\
             TCGv_i64 {self.reg_tcg()} = tcg_temp_new_i64();
-            gen_read_sreg_pair({self.reg_tcg()}, {self.reg_num});
         """))
     def log_write(self, f, tag):
         f.write(code_fmt(f"""\


### PR DESCRIPTION
NOTE: also reword commit message. Taylor's suggestion:

    target/hexagon: Handle system/guest registers in gen_analyze_funcs.py and hex_common.py