### PR TITLE
linux-user/hexagon: fix target_sigcontext alignment to agree with the kernel

### DIFF
--- a/linux-user/hexagon/signal.c
+++ b/linux-user/hexagon/signal.c
@@ -45,7 +45,7 @@ struct target_sigcontext {
     target_ulong cause;
     target_ulong badva;
     target_ulong pred[NUM_PREGS];
-};
+} QEMU_ALIGNED(8);
 
 struct target_ucontext {
     unsigned long uc_flags;


### PR DESCRIPTION
https://github.com/torvalds/linux/blob/fd94619c43360eb44d28bd3ef326a4f85c600a07/arch/hexagon/include/uapi/asm/sigcontext.h#L30-L32