### PR TITLE
semihosting lseek doesn't use whence.

### DIFF
--- a/target/hexagon/hexswi.c
+++ b/target/hexagon/hexswi.c
@@ -28,6 +28,7 @@
 
 /* non-arm-compatible semihosting calls */
 #define HEXAGON_SPECIFIC_SWI_FLAGS \
+    DEF_SWI_FLAG(SEEK,             0x0A) \
     DEF_SWI_FLAG(EXCEPTION,        0x18) \
     DEF_SWI_FLAG(READ_CYCLES,      0x40) \
     DEF_SWI_FLAG(PROF_ON,          0x41) \
@@ -324,6 +325,17 @@ static void sim_handle_trap0(CPUHexagonState *env)
         fflush(stdout);
         semi_cb(cs, 0, 0);
         break;
+
+    case HEX_SYS_SEEK:
+    {
+        int fd;
+        target_ulong off;
+        hexagon_read_memory(env, swi_info, 4, &fd, retaddr);
+        hexagon_read_memory(env, swi_info + 4, 4, &off, retaddr);
+        semihost_sys_lseek(env_cpu(env), common_semi_ftell_cb, fd, off,
+                          GDB_SEEK_SET);
+    }
+    break;
 
     case HEX_SYS_STAT:
     case HEX_SYS_FSTAT:


### PR DESCRIPTION
This addresses a failure in the pico-libc, test-fread-fwrite test.

Per the spec:
SYS_SEEK (0x0A)
Seeks to a specified position in a file using an offset specified from the start of the file. The file is assumed to be a byte array and the offset is given in bytes.

Entry
On entry, r1 contains a pointer to a two-word data block:

word 1
This is a handle for a seekable file object.

word 2
The absolute byte position to search to.

Change-Id: Ie3e7ea07a5623ee178a98484bbf1cdbdd3363a01