### PR TITLE
github-workflows: fix duplicate CI runs on push and pull_request

### DIFF
--- a/.github/workflows/macos-builds.yml
+++ b/.github/workflows/macos-builds.yml
@@ -3,7 +3,13 @@
 
 name: macOS Builds
 
-on: [ pull_request, push, workflow_dispatch, workflow_call ]
+on:
+  push:
+    branches:
+      - 'libqemu/**'
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/qcom-preflight-checks.yml
+++ b/.github/workflows/qcom-preflight-checks.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - 'libqemu/**'
-  push:
-    branches:
-      - 'libqemu/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ubuntu-builds.yml
+++ b/.github/workflows/ubuntu-builds.yml
@@ -3,7 +3,13 @@
 
 name: Ubuntu Builds
 
-on: [ pull_request, push, workflow_dispatch, workflow_call ]
+on:
+  push:
+    branches:
+      - 'libqemu/**'
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build-libqemu:

--- a/.github/workflows/windows-builds.yml
+++ b/.github/workflows/windows-builds.yml
@@ -3,7 +3,13 @@
 
 name: Windows Builds
 
-on: [ pull_request, push, workflow_dispatch, workflow_call ]
+on:
+  push:
+    branches:
+      - 'libqemu/**'
+  pull_request:
+  workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:


### PR DESCRIPTION
The build workflows triggered on both push and pull_request events
without branch filters, causing duplicate CI runs whenever a push was
made to a branch with an open PR. Fix this by restricting push triggers
to only the master and libqemu/** branches, while keeping pull_request
unrestricted for PR coverage.

Also remove the push trigger from qcom-preflight-checks.yml since
preflight checks (semgrep, dependency-review, etc.) are PR-centric and
don't need to run on direct pushes.

Signed-off-by: Matheus Tavares Bernardino <matheus.bernardino@oss.qualcomm.com>
