### PR TITLE
qemu.cmake: use ninja by default to build QEMU

### DIFF
--- a/qemu.cmake
+++ b/qemu.cmake
@@ -194,6 +194,7 @@ ExternalProject_Add(qemu
         --prefix=<INSTALL_DIR>
         --target-list=${target_list}
         ${QEMU_CONF_ARGS}
+    BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
     INSTALL_COMMAND ${CMAKE_MAKE_PROGRAM} install
     BUILD_ALWAYS on
 )


### PR DESCRIPTION
For external projects, CMake relies on recursive make when using Unix
Makefiles generator, which controls number of jobs with make jobserver
[1]. However, with ninja generator, it simply calls make. In case of
QEMU, this results in building it with -j1, which is slow.

Thus, tell cmake to use default make program, so we can use all our
cores by default with -G Ninja.

Note: For Ninja builds, we'll build with more cores than we have (qqvp
ninja jobs + QEMU ninja jobs), but since libqemu-build target blocks the
rest of qqvp build, I don't expect this to overload machine since
existing jobs will be finished during the time QEMU runs its long
configure step.

[1] https://cmake.org/cmake/help/latest/module/ExternalProject.html#build-step-options