### PR TITLE
qct-qtimer: add support for frame_stride property

### DIFF
--- a/hw/timer/qct-qtimer.c
+++ b/hw/timer/qct-qtimer.c
@@ -178,8 +178,10 @@ static MemTxResult hex_timer_read(void *opaque,
                                 MemTxAttrs attrs)
 {
     QCTQtimerState *qct_s = (QCTQtimerState*)opaque;
-    uint32_t slot_nr = (offset & 0xF000) >> 12;
-    uint32_t reg_offset = offset & 0xFFF;
+    uint32_t stride = qct_s->frame_stride;
+    uint32_t stride_shift = ctz32(stride);
+    uint32_t slot_nr = (offset & (0xF * stride)) >> stride_shift;
+    uint32_t reg_offset = offset & (stride - 1);
     uint32_t view = slot_nr % qct_s->nr_views;
     uint32_t frame = slot_nr / qct_s->nr_views;
 
@@ -326,8 +328,10 @@ static MemTxResult hex_timer_write(void *opaque,
                                     MemTxAttrs attrs)
 {
     QCTQtimerState *qct_s = (QCTQtimerState*)opaque;
-    uint32_t slot_nr = (offset & 0xF000) >> 12;
-    uint32_t reg_offset = offset & 0xFFF;
+    uint32_t stride = qct_s->frame_stride;
+    uint32_t stride_shift = ctz32(stride);
+    uint32_t slot_nr = (offset & (0xF * stride)) >> stride_shift;
+    uint32_t reg_offset = offset & (stride - 1);
     uint32_t view = slot_nr % qct_s->nr_views;
     uint32_t frame = slot_nr / qct_s->nr_views;
 
@@ -514,7 +518,7 @@ static void qct_qtimer_realize(DeviceState *dev, Error **errp)
     sysbus_init_mmio(sbd, &s->iomem);
 
     memory_region_init_io(&s->view_iomem, OBJECT(sbd), &hex_timer_ops, s,
-                          "qutimer_views", QTIMER_MEM_SIZE_BYTES * s->nr_frames * s->nr_views);
+                          "qutimer_views", s->frame_stride * s->nr_frames * s->nr_views);
     sysbus_init_mmio(sbd, &s->view_iomem);
 
     for (i = 0; i < s->nr_frames; i++) {
@@ -550,6 +554,7 @@ static const Property qct_qtimer_properties[] = {
     DEFINE_PROP_UINT32("freq", QCTQtimerState, freq, QTIMER_DEFAULT_FREQ_HZ),
     DEFINE_PROP_UINT32("nr_frames", QCTQtimerState, nr_frames, 2),
     DEFINE_PROP_UINT32("nr_views", QCTQtimerState, nr_views, 1),
+    DEFINE_PROP_UINT32("frame_stride", QCTQtimerState, frame_stride, 0x1000),
     DEFINE_PROP_ON_OFF_AUTO("start-ticking", QCTQtimerState, start_ticking,
                             ON_OFF_AUTO_AUTO),
     DEFINE_PROP_UINT32("cnttid_0", QCTQtimerState, cnttid_0, 0x11),

--- a/include/hw/timer/qct-qtimer.h
+++ b/include/hw/timer/qct-qtimer.h
@@ -55,6 +55,7 @@ struct QCTQtimerState {
     uint32_t freq;
     uint32_t nr_frames;
     uint32_t nr_views;
+    uint32_t frame_stride;
     OnOffAuto start_ticking;
     uint32_t cnttid_0;
     uint32_t cnttid_1;

--- a/tests/qtest/qct-qtimer-test.c
+++ b/tests/qtest/qct-qtimer-test.c
@@ -297,6 +297,29 @@ static void test_sa8775p_start_ticking_disabled(void)
     qtest_end();
 }
 
+static void test_qtimer_frame_stride(gconstpointer data)
+{
+    uint32_t stride = GPOINTER_TO_UINT(data);
+    uint32_t freq;
+    g_autofree char *args = g_strdup_printf(
+        "-machine virt -global qct-qtimer.frame_stride=0x%x", stride);
+
+    qtest_start(args);
+
+    freq = qtimer_read32(QTIMER_VIEW_BASE, QCT_QTIMER_CNT_FREQ);
+    g_assert_cmpuint(freq, ==, QTIMER_DEFAULT_FREQ_HZ);
+
+    freq = qtimer_read32(QTIMER_VIEW_BASE + stride, QCT_QTIMER_CNT_FREQ);
+    g_assert_cmpuint(freq, ==, QTIMER_DEFAULT_FREQ_HZ);
+
+    if (stride > 0x1000) {
+        freq = qtimer_read32(QTIMER_VIEW_BASE + 0x1000, QCT_QTIMER_CNT_FREQ);
+        g_assert_cmpuint(freq, ==, 0);
+    }
+
+    qtest_end();
+}
+
 int main(int argc, char **argv)
 {
     g_test_init(&argc, &argv, NULL);
@@ -314,6 +337,11 @@ int main(int argc, char **argv)
                    test_sa8775p_start_ticking);
     qtest_add_func("/qct-qtimer/SA8775P_CDSP0/start-ticking-disabled",
                    test_sa8775p_start_ticking_disabled);
+
+    qtest_add_data_func("/qct-qtimer/virt/frame-stride-2000",
+                        GUINT_TO_POINTER(0x2000), test_qtimer_frame_stride);
+    qtest_add_data_func("/qct-qtimer/virt/frame-stride-4000",
+                        GUINT_TO_POINTER(0x4000), test_qtimer_frame_stride);
 
     return g_test_run();
 }


### PR DESCRIPTION
- currently the frame stride is fixed to 0x1000, but it might happen that the frames have differnet stride size, so a new frame_stride property should be added to paramterize it.