### PR TITLE
Add new proprieties and wrappers functions

### DIFF
--- a/hw/hexagon/hexagon_testboard.c
+++ b/hw/hexagon/hexagon_testboard.c
@@ -378,7 +378,7 @@ static void create_cdsp_turing_rsc(void)
 
 static void hexagon_common_init(MachineState *machine, Rev_t rev,
                                 hexagon_machine_config *m_cfg,
-                                bool start_ticking)
+                                OnOffAuto ticker_ctrl)
 {
     memset(&hexagon_binfo, 0, sizeof(hexagon_binfo));
     if (machine->kernel_filename) {
@@ -502,9 +502,24 @@ static void hexagon_common_init(MachineState *machine, Rev_t rev,
     object_property_set_uint(OBJECT(qtimer), "nr_frames", 3, &error_fatal);
     object_property_set_uint(OBJECT(qtimer), "nr_views", 1, &error_fatal);
     object_property_set_uint(OBJECT(qtimer), "cnttid_0", 0x111, &error_fatal);
-    if (qtimer->start_ticking == ON_OFF_AUTO_AUTO) {
-        object_property_set_str(OBJECT(qtimer), "start-ticking",
-                                start_ticking ? "on" : "off", &error_fatal);
+    /* We need this 'if' in case of the test is setting it 
+     * with the command (i.e: -global qct-qtimer.ticker-ctrl=off 
+     */
+    if (qtimer->ticker_ctrl == ON_OFF_AUTO_AUTO) {
+        switch (ticker_ctrl) {
+        case ON_OFF_AUTO_ON:
+            object_property_set_str(OBJECT(qtimer), "ticker-ctrl", "on",
+                                    &error_fatal);
+            break;
+        case ON_OFF_AUTO_OFF:
+            object_property_set_str(OBJECT(qtimer), "ticker-ctrl", "off",
+                                    &error_fatal);
+            break;
+        case ON_OFF_AUTO_AUTO:
+        default:
+            /* leave as default (auto) */
+            break;
+        }
     }
     sysbus_realize_and_unref(SYS_BUS_DEVICE(qtimer), &error_fatal);
 
@@ -622,7 +637,7 @@ static void machcfg_disable_coproc(hexagon_machine_config *cfg)
 
 static void v66g_1024_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v66_rev, &v66g_1024, false);
+    hexagon_common_init(machine, v66_rev, &v66g_1024, ON_OFF_AUTO_AUTO);
 }
 
 static void v66g_1024_init(ObjectClass *oc, const void *data)
@@ -656,7 +671,7 @@ static void v66g_linux_init(ObjectClass *oc, const void *data)
 static void v68n_1024_config_init(MachineState *machine)
 
 {
-    hexagon_common_init(machine, v68_rev, &v68n_1024, false);
+    hexagon_common_init(machine, v68_rev, &v68n_1024, ON_OFF_AUTO_AUTO);
 }
 
 static void v68n_1024_init(ObjectClass *oc, const void *data)
@@ -691,7 +706,7 @@ static void v68n_h2_init(ObjectClass *oc, const void *data)
 
 static void v69na_1024_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v69_rev, &v69na_1024, false);
+    hexagon_common_init(machine, v69_rev, &v69na_1024, ON_OFF_AUTO_AUTO);
 }
 
 static void v69na_1024_init(ObjectClass *oc, const void *data)
@@ -707,19 +722,19 @@ static void v69na_1024_init(ObjectClass *oc, const void *data)
 
 static void v73na_1024_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v73_rev, &v73na_1024, false);
+    hexagon_common_init(machine, v73_rev, &v73na_1024, ON_OFF_AUTO_AUTO);
 }
 
 static void v73m_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v73m_rev, &v73m, false);
+    hexagon_common_init(machine, v73m_rev, &v73m, ON_OFF_AUTO_AUTO);
 }
 
 #include "smem_entries.inc"
 
 static void SA8775P_cdsp0_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v73_rev, &SA8775P_cdsp0, true);
+    hexagon_common_init(machine, v73_rev, &SA8775P_cdsp0, ON_OFF_AUTO_ON);
 
     /* Create and map the TCSR device */
     DeviceState *tcsr = qdev_new(TYPE_TCSR);
@@ -809,7 +824,7 @@ static void SA8775P_cdsp0_init(ObjectClass *oc, const void *data)
 
 static void SA8540P_cdsp0_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v68_rev, &SA8540P_cdsp0, false);
+    hexagon_common_init(machine, v68_rev, &SA8540P_cdsp0, ON_OFF_AUTO_AUTO);
 }
 
 static void SA8540P_cdsp0_init(ObjectClass *oc, const void *data)
@@ -826,7 +841,7 @@ static void SA8540P_cdsp0_init(ObjectClass *oc, const void *data)
 
 static void SA8797P_nsp0_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v81_rev, &SA8797P_nsp0, false);
+    hexagon_common_init(machine, v81_rev, &SA8797P_nsp0, ON_OFF_AUTO_AUTO);
 }
 
 static void SA8797P_nsp0_init(ObjectClass *oc, const void *data)
@@ -884,7 +899,7 @@ static void v73m_init(ObjectClass *oc, const void *data)
 
 static void v75na_1024_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v75_rev, &v75na_1024, false);
+    hexagon_common_init(machine, v75_rev, &v75na_1024, ON_OFF_AUTO_AUTO);
 }
 
 static void sim_nocoproc_config_init(MachineState *machine)
@@ -892,12 +907,12 @@ static void sim_nocoproc_config_init(MachineState *machine)
     hexagon_machine_config v81dgb_1_nocoproc;
     memcpy(&v81dgb_1_nocoproc, &v81dgb_1, sizeof(v81dgb_1));
     machcfg_disable_coproc(&v81dgb_1_nocoproc);
-    hexagon_common_init(machine, unknown_rev, &v81dgb_1_nocoproc, false);
+    hexagon_common_init(machine, unknown_rev, &v81dgb_1_nocoproc, ON_OFF_AUTO_AUTO);
 }
 
 static void sim_coproc_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, unknown_rev, &v75na_1024, false);
+    hexagon_common_init(machine, unknown_rev, &v75na_1024, ON_OFF_AUTO_AUTO);
 }
 
 static void v75na_1024_linux_config_init(MachineState *machine)
@@ -931,7 +946,7 @@ static void v75na_1024_init(ObjectClass *oc, const void *data)
 
 static void v79na_1_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v79_rev, &v79na_1, false);
+    hexagon_common_init(machine, v79_rev, &v79na_1, ON_OFF_AUTO_AUTO);
 }
 
 static void v79na_1_linux_config_init(MachineState *machine)
@@ -943,7 +958,7 @@ static void v79na_1_linux_config_init(MachineState *machine)
 
 static void v79m_1_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v79m_1_rev, &v79m_1, false);
+    hexagon_common_init(machine, v79m_1_rev, &v79m_1, ON_OFF_AUTO_AUTO);
 }
 
 static void v79na_1_linux_init(ObjectClass *oc, const void *data)
@@ -981,7 +996,7 @@ static void v79m_1_init(ObjectClass *oc, const void *data)
 
 static void v81qa_1_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v81_rev, &v81qa_1, false);
+    hexagon_common_init(machine, v81_rev, &v81qa_1, ON_OFF_AUTO_AUTO);
 }
 
 static void v81qa_1_init(ObjectClass *oc, const void *data)
@@ -1000,7 +1015,7 @@ static void v81qa_1_init(ObjectClass *oc, const void *data)
 
 static void v81na_2_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v81na_2_rev, &v81na_2, false);
+    hexagon_common_init(machine, v81na_2_rev, &v81na_2, ON_OFF_AUTO_AUTO);
 }
 
 static void v81na_2_init(ObjectClass *oc, const void *data)
@@ -1019,7 +1034,7 @@ static void v81na_2_init(ObjectClass *oc, const void *data)
 
 static void v81dgb_1_config_init(MachineState *machine)
 {
-    hexagon_common_init(machine, v81dgb_1_rev, &v81dgb_1, false);
+    hexagon_common_init(machine, v81dgb_1_rev, &v81dgb_1, ON_OFF_AUTO_AUTO);
 }
 
 static void v81dgb_1_init(ObjectClass *oc, const void *data)

--- a/hw/timer/qct-qtimer.c
+++ b/hw/timer/qct-qtimer.c
@@ -375,17 +375,19 @@ static MemTxResult hex_timer_write(void *opaque,
 
             s->int_level = 0;
             s->cntval = value;
-            ptimer_transaction_begin(s->timer);
-            if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
-                /* Pause the timer if it is running.  This may cause some
-                   inaccuracy due to rounding, but avoids other issues. */
-                ptimer_stop(s->timer);
+            if (s->qtimer->ticker_ctrl != ON_OFF_AUTO_OFF) {
+                ptimer_transaction_begin(s->timer);
+                if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
+                    /* Pause the timer if it is running.  This may cause some
+                       inaccuracy due to rounding, but avoids other issues. */
+                    ptimer_stop(s->timer);
+                }
+                hex_timer_recalibrate(s, 1);
+                if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
+                    ptimer_run(s->timer, 0);
+                }
+                ptimer_transaction_commit(s->timer);
             }
-            hex_timer_recalibrate(s, 1);
-            if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
-                ptimer_run(s->timer, 0);
-            }
-            ptimer_transaction_commit(s->timer);
             break;
         case (QCT_QTIMER_CNTP_CVAL_HI):
             if(!(s->cnt_ctrl & QCT_QTIMER_AC_CNTACR_RWPT)) {
@@ -406,6 +408,11 @@ static MemTxResult hex_timer_write(void *opaque,
 
             if (view && !(s->cntpl0acr & QCT_QTIMER_CNTPL0ACR_PL0CTEN)) {
                 return MEMTX_ACCESS_ERROR;
+            }
+
+            if (s->qtimer->ticker_ctrl != ON_OFF_AUTO_AUTO) {
+                s->control = value;
+                break;
             }
 
             ptimer_transaction_begin(s->timer);
@@ -432,19 +439,25 @@ static MemTxResult hex_timer_write(void *opaque,
                 return MEMTX_ACCESS_ERROR;
             }
 
-            ptimer_transaction_begin(s->timer);
-            if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
-                /* Pause the timer if it is running.  This may cause some
-                   inaccuracy due to rounding, but avoids other issues. */
-                ptimer_stop(s->timer);
+            /* TVAL write: CVAL = CNTPCT + TVAL (TVAL is signed 32-bit) */
+            s->cntval = s->cntpct + ptimer_get_count(s->timer)
+                        + (int64_t)(int32_t)value;
+
+            if (s->qtimer->ticker_ctrl != ON_OFF_AUTO_OFF) {
+                ptimer_transaction_begin(s->timer);
+                if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
+                    /* Pause the timer if it is running.  This may cause some
+                    inaccuracy due to rounding, but avoids other issues. */
+                    ptimer_stop(s->timer);
+                }
+
+                ptimer_set_freq(s->timer, s->freq);
+                ptimer_set_period(s->timer, 1);
+                if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
+                    ptimer_run(s->timer, 0);
+                }
+                ptimer_transaction_commit(s->timer);
             }
-            s->cntval = s->cntpct + value;
-            ptimer_set_freq(s->timer, s->freq);
-            ptimer_set_period(s->timer, 1);
-            if (s->control & QCT_QTIMER_CNTP_CTL_ENABLE) {
-                ptimer_run(s->timer, 0);
-            }
-            ptimer_transaction_commit(s->timer);
             break;
         case QCT_QTIMER_CNTPL0ACR:
             if (view) {
@@ -523,7 +536,11 @@ static void qct_qtimer_realize(DeviceState *dev, Error **errp)
 
     for (i = 0; i < s->nr_frames; i++) {
         s->timer[i].limit = 1;
-        s->timer[i].control = QCT_QTIMER_CNTP_CTL_ENABLE;
+        /* With ticker_ctrl=off, keep ENABLE=0 so SW must explicitly enable
+         * the timer. Otherwise default to ENABLE=1. */
+        s->timer[i].control = (s->ticker_ctrl == ON_OFF_AUTO_OFF)
+                              ? 0
+                              : QCT_QTIMER_CNTP_CTL_ENABLE;
         s->timer[i].cnt_ctrl = (QCT_QTIMER_AC_CNTACR_RWPT | QCT_QTIMER_AC_CNTACR_RWVT |
                     QCT_QTIMER_AC_CNTACR_RVOFF | QCT_QTIMER_AC_CNTACR_RFRQ |
                     QCT_QTIMER_AC_CNTACR_RPVCT | QCT_QTIMER_AC_CNTACR_RPCT);
@@ -538,7 +555,7 @@ static void qct_qtimer_realize(DeviceState *dev, Error **errp)
         vmstate_register(NULL, VMSTATE_INSTANCE_ID_ANY, &vmstate_hex_timer, &s->timer[i]);
     }
 
-    if (s->start_ticking == ON_OFF_AUTO_ON) {
+    if (s->ticker_ctrl == ON_OFF_AUTO_ON) {
         for (i = 0; i < s->nr_frames; i++) {
             ptimer_transaction_begin(s->timer[i].timer);
             ptimer_set_limit(s->timer[i].timer, s->timer[i].limit, 1);
@@ -555,7 +572,7 @@ static const Property qct_qtimer_properties[] = {
     DEFINE_PROP_UINT32("nr_frames", QCTQtimerState, nr_frames, 2),
     DEFINE_PROP_UINT32("nr_views", QCTQtimerState, nr_views, 1),
     DEFINE_PROP_UINT32("frame_stride", QCTQtimerState, frame_stride, 0x1000),
-    DEFINE_PROP_ON_OFF_AUTO("start-ticking", QCTQtimerState, start_ticking,
+    DEFINE_PROP_ON_OFF_AUTO("ticker-ctrl", QCTQtimerState, ticker_ctrl,
                             ON_OFF_AUTO_AUTO),
     DEFINE_PROP_UINT32("cnttid_0", QCTQtimerState, cnttid_0, 0x11),
     DEFINE_PROP_UINT32("cnttid_1", QCTQtimerState, cnttid_1, 0x0),

--- a/include/hw/timer/qct-qtimer.h
+++ b/include/hw/timer/qct-qtimer.h
@@ -56,7 +56,7 @@ struct QCTQtimerState {
     uint32_t nr_frames;
     uint32_t nr_views;
     uint32_t frame_stride;
-    OnOffAuto start_ticking;
+    OnOffAuto ticker_ctrl;
     uint32_t cnttid_0;
     uint32_t cnttid_1;
 };

--- a/libqemu/exports.py
+++ b/libqemu/exports.py
@@ -71,6 +71,18 @@ ExportedFct('object_property_parse', 'bool',
         ['Object *', 'const char *', 'const char *', 'Error **'],
         iothread_locked = True)
 
+ExportedFct('object_property_get_str' , 'const char *',
+        [ 'Object *', 'const char *', 'Error **' ], iothread_locked = True)
+
+ExportedFct('object_property_get_bool', 'bool',
+        [ 'Object *', 'const char *' , 'Error **' ], iothread_locked = True)
+
+ExportedFct('object_property_get_int' , 'int',
+        [ 'Object *', 'const char *', 'Error **' ], iothread_locked = True)
+
+ExportedFct('object_property_get_uint', 'uint64_t',
+        [ 'Object *', 'const char *', 'Error **' ], iothread_locked = True)
+
 ExportedFct('object_property_get_link', 'Object *',
         ['Object *', 'const char *', 'Error **'],
         iothread_locked = True)
@@ -394,8 +406,13 @@ ExportedType('qemu_plugin_hwaddr')
 ExportedType('qemu_plugin_scoreboard')
 ExportedType('qemu_plugin_register')
 
+# ARM specific exports (32-bit and 64-bit)
+PrivateInclude('libqemu/wrappers/target/arm.h', arch = 'arm')
+ExportedFct('cpu_arm_set_cpu_on_and_reset', 'int', [ 'Object *'],
+        priv = 'libqemu_arm_set_cpu_on_and_reset', arch = 'arm')
+ExportedFct('cpu_arm_set_cpu_off', 'int', [ 'Object *'],
+        priv = 'libqemu_arm_set_cpu_off', arch = 'arm')
 # AArch64 specific exports
-PrivateInclude('libqemu/wrappers/target/arm.h', arch = 'aarch64')
 ExportedFct('cpu_arm_set_cp15_cbar', 'void', [ 'Object *', 'uint64_t' ],
         priv = 'libqemu_cpu_arm_set_cp15_cbar', arch = 'aarch64')
 ExportedFct('cpu_arm_add_nvic_link', 'void', [ 'Object *' ],

--- a/libqemu/exports.py
+++ b/libqemu/exports.py
@@ -408,6 +408,8 @@ ExportedType('qemu_plugin_register')
 
 # ARM specific exports (32-bit and 64-bit)
 PrivateInclude('libqemu/wrappers/target/arm.h', arch = 'arm')
+ExportedFct('cpu_arm_set_imp_buildoptr', 'void', [ 'Object *', 'uint32_t' ],
+        priv = 'libqemu_cpu_arm_set_imp_buildoptr', arch = 'arm')
 ExportedFct('cpu_arm_set_cpu_on_and_reset', 'int', [ 'Object *'],
         priv = 'libqemu_arm_set_cpu_on_and_reset', arch = 'arm')
 ExportedFct('cpu_arm_set_cpu_off', 'int', [ 'Object *'],

--- a/libqemu/wrappers/target/arm.c
+++ b/libqemu/wrappers/target/arm.c
@@ -37,25 +37,14 @@ void libqemu_cpu_arm_set_cp15_cbar(Object *obj, uint64_t cbar)
     ARMCPU *cpu = ARM_CPU(obj);
     CPUARMState *env = &cpu->env;
 
-    if (arm_feature(env, ARM_FEATURE_CBAR_RO)) {
-        /* XXX discarding const qualifier here to avoid modifying QEMU upstream code */
-        uint32_t id = ENCODE_CP_REG(15, 0, 1, 15, 0, 4, 0);
-        ARMCPRegInfo *cbar_info = (ARMCPRegInfo *) get_arm_cp_reginfo(cpu->cp_regs, id);
-        assert(cbar_info);
-        cbar_info->resetvalue = cbar;
-    } else {
+    cpu->reset_cbar = cbar;
+
+    /* If CPU is already realized, update the runtime value for ARMv7 */
+    if (!arm_feature(env, ARM_FEATURE_V8)) {
         env->cp15.c15_config_base_address = cbar;
     }
 
-#if 0
-    if (arm_feature(env, ARM_FEATURE_AARCH64)) {
-        /* For AArch64, also update the 32 bits view */
-        uint32_t id = ENCODE_AA64_CP_REG(0, 15, 3, 3, 1, 0);
-        ARMCPRegInfo *cbar_info = (ARMCPRegInfo *) get_arm_cp_reginfo(cpu->cp_regs, id);
-        assert(cbar_info);
-        cbar_info->resetvalue = cbar;
-    }
-#endif
+    /* Note: For ARMv8, CBAR is ARM_CP_CONST, so only reset_cbar matters */
 }
 
 

--- a/libqemu/wrappers/target/arm.c
+++ b/libqemu/wrappers/target/arm.c
@@ -48,6 +48,18 @@ void libqemu_cpu_arm_set_cp15_cbar(Object *obj, uint64_t cbar)
     /* Note: For ARMv8, CBAR is ARM_CP_CONST, so only reset_cbar matters */
 }
 
+/* This ARM register is only available for Cortex-R52 */
+void libqemu_cpu_arm_set_imp_buildoptr(Object *obj, uint32_t imp_buildoptr_val)
+{
+    ARMCPU *cpu = ARM_CPU(obj);
+
+    uint32_t id = ENCODE_CP_REG(15, 0, 1, 15, 2, 0, 0);
+    ARMCPRegInfo *imp_buildoptr_info =
+        (ARMCPRegInfo *)get_arm_cp_reginfo(cpu->cp_regs, id);
+    assert(imp_buildoptr_info);
+    imp_buildoptr_info->resetvalue = imp_buildoptr_val;
+}
+
 int libqemu_arm_set_cpu_on_and_reset(Object *obj)
 {
     Error *err = NULL;

--- a/libqemu/wrappers/target/arm.c
+++ b/libqemu/wrappers/target/arm.c
@@ -22,6 +22,7 @@
 #include "target/arm/cpu.h"
 #include "target/arm/cpu-qom.h"
 #include "target/arm/cpregs.h"
+#include "target/arm/arm-powerctl.h"
 #include "hw/core/qdev-properties.h"
 #include "hw/intc/armv7m_nvic.h"
 #include "system/kvm.h"
@@ -47,6 +48,41 @@ void libqemu_cpu_arm_set_cp15_cbar(Object *obj, uint64_t cbar)
     /* Note: For ARMv8, CBAR is ARM_CP_CONST, so only reset_cbar matters */
 }
 
+int libqemu_arm_set_cpu_on_and_reset(Object *obj)
+{
+    Error *err = NULL;
+
+    uint64_t cpuid = object_property_get_uint(obj, "mp-affinity", &err);
+    if (err) {
+        fprintf(
+            stderr,
+            "libqemu_arm_set_cpu_on_and_reset: error getting property: %s\n",
+            error_get_pretty(err));
+        error_free(err);
+        return QEMU_ARM_POWERCTL_INVALID_PARAM;
+    }
+
+    int ret = arm_set_cpu_on_and_reset(cpuid);
+
+    return ret;
+}
+
+int libqemu_arm_set_cpu_off(Object *obj)
+{
+    Error *err = NULL;
+
+    uint64_t cpuid = object_property_get_uint(obj, "mp-affinity", &err);
+    if (err) {
+        fprintf(stderr, "libqemu_arm_set_cpu_off: error getting property: %s\n",
+                error_get_pretty(err));
+        error_free(err);
+        return QEMU_ARM_POWERCTL_INVALID_PARAM;
+    }
+
+    int ret = arm_set_cpu_off(cpuid);
+
+    return ret;
+}
 
 void libqemu_cpu_aarch64_set_aarch64_mode(Object *obj, bool aarch64_mode)
 {

--- a/libqemu/wrappers/target/arm.h
+++ b/libqemu/wrappers/target/arm.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 
 void libqemu_cpu_arm_set_cp15_cbar(Object *cpu, uint64_t cbar);
+void libqemu_cpu_arm_set_imp_buildoptr(Object *obj, uint32_t imp_buildoptr_val);
 void libqemu_cpu_aarch64_set_aarch64_mode(Object *cpu, bool aarch64_mode);
 
 int libqemu_arm_set_cpu_on_and_reset(Object *cpu);

--- a/libqemu/wrappers/target/arm.h
+++ b/libqemu/wrappers/target/arm.h
@@ -26,6 +26,9 @@
 void libqemu_cpu_arm_set_cp15_cbar(Object *cpu, uint64_t cbar);
 void libqemu_cpu_aarch64_set_aarch64_mode(Object *cpu, bool aarch64_mode);
 
+int libqemu_arm_set_cpu_on_and_reset(Object *cpu);
+int libqemu_arm_set_cpu_off(Object *cpu);
+
 void libqemu_cpu_arm_add_nvic_link(Object *cpu);
 void libqemu_arm_nvic_add_cpu_link(Object *cpu);
 

--- a/target/arm/cpu.c
+++ b/target/arm/cpu.c
@@ -1219,6 +1219,11 @@ static const Property arm_cpu_pmsav7_dregion_property =
             DEFINE_PROP_UNSIGNED_NODEFAULT("pmsav7-dregion", ARMCPU,
                                            pmsav7_dregion,
                                            qdev_prop_uint32, uint32_t);
+
+static const Property arm_cpu_pmsav8r_hdregion_property =
+            DEFINE_PROP_UNSIGNED_NODEFAULT("pmsav8r-hdregion", ARMCPU,
+                                           pmsav8r_hdregion,
+                                           qdev_prop_uint32, uint32_t);
 #endif
 
 static bool arm_get_pmu(Object *obj, Error **errp)
@@ -1496,6 +1501,10 @@ static void arm_cpu_post_init(Object *obj)
         if (arm_feature(&cpu->env, ARM_FEATURE_V7)) {
             qdev_property_add_static(DEVICE(obj),
                                      &arm_cpu_pmsav7_dregion_property);
+        }
+        if (arm_feature(&cpu->env, ARM_FEATURE_V8)) {
+            qdev_property_add_static(DEVICE(obj),
+                                     &arm_cpu_pmsav8r_hdregion_property);
         }
     }
 

--- a/tests/qtest/qct-qtimer-test.c
+++ b/tests/qtest/qct-qtimer-test.c
@@ -281,7 +281,7 @@ static void test_sa8775p_start_ticking_disabled(void)
     uint64_t count1, count2;
 
     qtest_start("-machine SA8775P_CDSP0 "
-                "-global qct-qtimer.start-ticking=off");
+                "-global qct-qtimer.ticker-ctrl=off");
 
     qtest_clock_step(global_qtest, 1000);
 


### PR DESCRIPTION
- CortexR52: Add new pmsav8r_hdregion property
- Update set_cp15_cbar wrapper function
- Add new wrappers functions and export them with getter functions
- Add new wrapper function to set IMP_BUILDOPTR register
- qct-qtimer: add ticker-ctrl property and remove the start-ticking one (OnOffAuto)