### PR TITLE
target/riscv: SOCCP support — platform-defined local interrupts and vendor CSR

### DIFF
--- a/target/riscv/cpu.c
+++ b/target/riscv/cpu.c
@@ -1054,7 +1054,20 @@ static void riscv_cpu_set_irq(void *opaque, int irq, int level)
             }
             break;
         default:
-            g_assert_not_reached();
+            /*
+             * Handle non-standard local interrupts (IRQ >= 12, < IRQ_LOCAL_MAX).
+             * The RISC-V spec reserves IRQ numbers 12+ for platform-defined
+             * local interrupts. These are used by custom CLINT implementations
+             * (e.g., Qualcomm SC8480XP uses IRQ 21 for RSC DRV0, IRQ 27 for qtimer).
+             * Treat them the same as standard interrupts: set the corresponding
+             * MIP bit so firmware can detect and handle them.
+             */
+            if (irq >= 12) {
+                riscv_cpu_update_mip(env, 1 << irq, BOOL_TO_MASK(level));
+            } else {
+                g_assert_not_reached();
+            }
+            break;
         }
     } else if (irq < (IRQ_LOCAL_MAX + IRQ_LOCAL_GUEST_MAX)) {
         /* Require H-extension for handling guest local interrupts */

--- a/target/riscv/csr.c
+++ b/target/riscv/csr.c
@@ -6661,5 +6661,12 @@ riscv_csr_operations csr_ops[CSR_TABLE_SIZE] = {
     [CSR_SCOUNTOVF]      = { "scountovf", sscofpmf,  read_scountovf,
                              .min_priv_ver = PRIV_VERSION_1_12_0 },
 
+    /* Vendor-specific CSRs (Qualcomm/SiFive) */
+    /* CSR 0x7c1: Core disable register used by Qualcomm SOCCP firmware
+     * to disable speculative i-cache fill and turn off core clocks.
+     * Treated as no-op in QEMU since these are power optimizations
+     * with no functional effect on simulation. */
+    [0x7c1] = { "vendor_core_disable", any, read_zero, write_ignore },
+
 #endif /* !CONFIG_USER_ONLY */
 };


### PR DESCRIPTION
Adds the RISC-V core support required by the Glymur SC8480XP SOCCP subsystem, rebased onto v11

Main Changes:
- target/riscv: handle platform-defined local interrupts (IRQ >= 12)
    Allows local interrupt sources at IRQ index ≥ 12 (platform-defined range) to
    be delivered to the RISC-V core, as required by the SOCCP PLIC wiring.
- target/riscv: add vendor CSR 0x7c1 as no-op
    Registers vendor CSR `0x7c1` as a read/write no-op so SOCCP firmware that
    touches it does not trap with an illegal-instruction exception.