### PR TITLE
virtio-gpu: Fix vircl OpenCL device (capsets, QOM type, timers)

### DIFF
--- a/hw/display/virtio-gpu-cl.c
+++ b/hw/display/virtio-gpu-cl.c
@@ -126,10 +126,25 @@ static void virtio_gpu_gl_device_realize(DeviceState *qdev, Error **errp)
     }
 
     g->parent_obj.conf.flags |= (1 << VIRTIO_GPU_FLAG_VIRGL_ENABLED);
-    VIRTIO_GPU_BASE(g)->virtio_config.num_capsets =
-        virtio_gpu_vircl_get_num_capsets(g);
+    g->capset_ids = virtio_gpu_vircl_get_capsets(g);
+    VIRTIO_GPU_BASE(g)->virtio_config.num_capsets = g->capset_ids->len;
 
     virtio_gpu_device_realize(qdev, errp);
+}
+
+static void virtio_gpu_gl_device_unrealize(DeviceState *qdev)
+{
+    VirtIOGPU *g = VIRTIO_GPU(qdev);
+    VirtIOGPUCL *gl = VIRTIO_GPU_CL(qdev);
+
+    if (gl->renderer_inited) {
+        if (virtio_gpu_stats_enabled(g->parent_obj.conf)) {
+            timer_free(gl->print_stats);
+        }
+        timer_free(gl->fence_poll);
+    }
+
+    g_array_unref(g->capset_ids);
 }
 
 static const Property virtio_gpu_gl_properties[] = {
@@ -150,6 +165,7 @@ static void virtio_gpu_gl_class_init(ObjectClass *klass, const void *data)
     vgc->update_cursor_data = virtio_gpu_gl_update_cursor_data;
 
     vdc->realize = virtio_gpu_gl_device_realize;
+    vdc->unrealize = virtio_gpu_gl_device_unrealize;
     vdc->reset = virtio_gpu_gl_reset;
     device_class_set_props(dc, virtio_gpu_gl_properties);
 }

--- a/hw/display/virtio-gpu-vircl.c
+++ b/hw/display/virtio-gpu-vircl.c
@@ -769,7 +769,7 @@ static struct virgl_renderer_callbacks virtio_gpu_3d_cbs = {
 static void virtio_gpu_print_stats(void *opaque)
 {
     VirtIOGPU *g = opaque;
-    VirtIOGPUGL *gl = VIRTIO_GPU_GL(g);
+    VirtIOGPUCL *gl = VIRTIO_GPU_CL(g);
 
     if (g->stats.requests) {
         fprintf(stderr, "stats: vq req %4d, %3d -- 3D %4d (%5d)\n",
@@ -790,7 +790,7 @@ static void virtio_gpu_print_stats(void *opaque)
 static void virtio_gpu_fence_poll(void *opaque)
 {
     VirtIOGPU *g = opaque;
-    VirtIOGPUGL *gl = VIRTIO_GPU_GL(g);
+    VirtIOGPUCL *gl = VIRTIO_GPU_CL(g);
 
     vircl_renderer_poll();
     virtio_gpu_process_cmdq(g);
@@ -823,7 +823,7 @@ int virtio_gpu_vircl_init(VirtIOGPU *g)
 {
     int ret;
     uint32_t flags = 0;
-    VirtIOGPUGL *gl = VIRTIO_GPU_GL(g);
+    VirtIOGPUCL *gl = VIRTIO_GPU_CL(g);
 
 #if defined(VIRGL_RENDERER_CALLBACKS_VERSION) && \
     VIRGL_RENDERER_CALLBACKS_VERSION >= 4
@@ -855,22 +855,41 @@ int virtio_gpu_vircl_init(VirtIOGPU *g)
     return 0;
 }
 
-static void capset_add(VirtIOGPU *g, uint32_t capset, bool check_ver)
+/*
+ * How a capset's availability is gated before being advertised to the guest.
+ * The renderer reports both a max version and a max blob size per capset; the
+ * different capsets are validated against different fields (matching the
+ * historic per-capset checks), so the gate must be selected explicitly.
+ */
+typedef enum {
+    CAPSET_GATE_NONE,   /* always advertise */
+    CAPSET_GATE_VERSION, /* advertise only if the renderer reports a version */
+    CAPSET_GATE_SIZE,   /* advertise only if the renderer reports a blob size */
+} CapsetGate;
+
+static void capset_add(GArray *capset_ids, uint32_t capset, CapsetGate gate)
 {
     uint32_t capset_max_ver, capset_max_size;
-    if (check_ver) {
+
+    if (gate != CAPSET_GATE_NONE) {
         vircl_renderer_get_cap_set(capset, &capset_max_ver, &capset_max_size);
+        if (gate == CAPSET_GATE_VERSION && !capset_max_ver) {
+            return;
+        }
+        if (gate == CAPSET_GATE_SIZE && !capset_max_size) {
+            return;
+        }
     }
-    if (!check_ver || capset_max_ver) {
-        g_array_append_val(g->capset_ids, capset);
-    }
+    g_array_append_val(capset_ids, capset);
 }
 
-int virtio_gpu_vircl_get_num_capsets(VirtIOGPU *g)
+GArray *virtio_gpu_vircl_get_capsets(VirtIOGPU *g)
 {
-    capset_add(g, VIRTIO_GPU_CAPSET_VIRGL, false);
-    capset_add(g, VIRTIO_GPU_CAPSET_VIRGL2, true);
-    capset_add(g, VIRTIO_GPU_CAPSET_VENUS, true);
-    capset_add(g, VIRTIO_GPU_CAPSET_VCL, true);
-    return g->capset_ids->len;
+    GArray *capset_ids = g_array_new(false, false, sizeof(uint32_t));
+
+    capset_add(capset_ids, VIRTIO_GPU_CAPSET_VIRGL,  CAPSET_GATE_NONE);
+    capset_add(capset_ids, VIRTIO_GPU_CAPSET_VIRGL2, CAPSET_GATE_VERSION);
+    capset_add(capset_ids, VIRTIO_GPU_CAPSET_VENUS,  CAPSET_GATE_SIZE);
+    capset_add(capset_ids, VIRTIO_GPU_CAPSET_VCL,    CAPSET_GATE_SIZE);
+    return capset_ids;
 }

--- a/include/hw/virtio/virtio-gpu.h
+++ b/include/hw/virtio/virtio-gpu.h
@@ -282,6 +282,9 @@ struct VirtIOGPUCL {
 
     bool renderer_inited;
     bool renderer_reset;
+
+    QEMUTimer *fence_poll;
+    QEMUTimer *print_stats;
 };
 
 struct VirtIOGPUQNN {
@@ -434,7 +437,7 @@ void virtio_gpu_vircl_fence_poll(VirtIOGPU *g);
 void virtio_gpu_vircl_reset_scanout(VirtIOGPU *g);
 void virtio_gpu_vircl_reset(VirtIOGPU *g);
 int virtio_gpu_vircl_init(VirtIOGPU *g);
-int virtio_gpu_vircl_get_num_capsets(VirtIOGPU *g);
+GArray *virtio_gpu_vircl_get_capsets(VirtIOGPU *g);
 #ifdef HAVE_VCL_RESOURCE_BLOB
 int virtio_gpu_vircl_resource_unmap(VirtIOGPU *g,
                                     struct virtio_gpu_simple_resource *res);


### PR DESCRIPTION
Fix the vircl OpenCL device broken by the virglrenderer refactoring in qemu 10.