### PR TITLE
plugins/win32: resolve delay-loaded plugin symbols from libqbox.dll

### DIFF
--- a/plugins/win32_linker.c
+++ b/plugins/win32_linker.c
@@ -28,6 +28,17 @@ FARPROC WINAPI dll_failure_hook(unsigned dliNotify, PDelayLoadInfo pdli) {
             return (FARPROC) top;
         }
     }
+    if (dliNotify == dliFailGetProc && pdli->dlp.szProcName) {
+        /*
+         * GetProcAddress failed on the module returned by dliFailLoadLib
+         * (the EXE). The symbol may live in libqbox.dll instead
+         * (e.g. global_set_cci_param), so try resolving it there.
+         */
+        HMODULE qbox = GetModuleHandleA("libqbox.dll");
+        if (qbox) {
+            return GetProcAddress(qbox, pdli->dlp.szProcName);
+        }
+    }
     /* Otherwise we can't do anything special. */
     return 0;
 }


### PR DESCRIPTION
  A libqemu plugin such as idlinker delay-imports global_set_cci_param
  from the fictional qemu.exe. The existing dliFailLoadLib hook redirects
  that load to GetModuleHandle(NULL) (the host EXE), which is correct for
  standalone QEMU where the plugin API symbols live in the executable.

  When libqemu is embedded (e.g. qbox), those symbols live in libqbox.dll
  rather than the EXE, so GetProcAddress on the EXE handle fails and the
  delay-load helper raises 0xC06D007F (ERROR_PROC_NOT_FOUND).

  Handle dliFailGetProc as a fallback: when the symbol is not found on the
  module returned for the failed load, resolve it from libqbox.dll. This
  fires only after the normal EXE lookup fails, so standalone QEMU is
  unaffected.