### PR TITLE
libqemu: auto-generate TCG plugin API exports from qemu-plugin.h

### DIFF
--- a/libqemu/exports.py
+++ b/libqemu/exports.py
@@ -392,129 +392,13 @@ ExportedFct('finish_qemu_init', 'void', [ ], priv='finish_qemu_init', on_iothrea
 ExportedFct('sysbus_get_default', 'BusState *', [ ])
 
 
-# TCG PLUGIN API exports
+# TCG PLUGIN API exports, generated automatically from the plugin header.
+# Every function marked QEMU_PLUGIN_API in include/plugins/qemu-plugin.h is
+# exported; changes to the API (new functions, changed parameter lists) are
+# picked up automatically on the next build.
 PublicInclude('plugins/qemu-plugin.h')
 PrivateInclude('qemu/plugin.h')
-
-ExportedFct('qemu_plugin_uninstall', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_simple_cb_t'])
-ExportedFct('qemu_plugin_reset', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_simple_cb_t'])
-ExportedFct('qemu_plugin_register_vcpu_init_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_simple_cb_t'])
-ExportedFct('qemu_plugin_register_vcpu_exit_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_simple_cb_t'])
-ExportedFct('qemu_plugin_register_vcpu_idle_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_simple_cb_t'])
-ExportedFct('qemu_plugin_register_vcpu_resume_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_simple_cb_t'])
-ExportedFct('qemu_plugin_register_vcpu_tb_trans_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_tb_trans_cb_t'])
-ExportedFct('qemu_plugin_register_vcpu_tb_exec_cb', 'void',
-            ['struct qemu_plugin_tb *', 'qemu_plugin_vcpu_udata_cb_t',
-             'enum qemu_plugin_cb_flags', 'void *'])
-ExportedFct('qemu_plugin_register_vcpu_tb_exec_cond_cb', 'void',
-            ['struct qemu_plugin_tb *', 'qemu_plugin_vcpu_udata_cb_t',
-             'enum qemu_plugin_cb_flags', 'enum qemu_plugin_cond',
-             'qemu_plugin_u64', 'uint64_t', 'void *'])
-ExportedFct('qemu_plugin_register_vcpu_tb_exec_inline_per_vcpu', 'void',
-            ['struct qemu_plugin_tb *', 'enum qemu_plugin_op',
-             'qemu_plugin_u64', 'uint64_t'])
-ExportedFct('qemu_plugin_register_vcpu_insn_exec_cb', 'void',
-            ['struct qemu_plugin_insn *', 'qemu_plugin_vcpu_udata_cb_t',
-             'enum qemu_plugin_cb_flags', 'void *'])
-ExportedFct('qemu_plugin_register_vcpu_insn_exec_cond_cb', 'void',
-            ['struct qemu_plugin_insn *', 'qemu_plugin_vcpu_udata_cb_t',
-             'enum qemu_plugin_cb_flags', 'enum qemu_plugin_cond',
-             'qemu_plugin_u64', 'uint64_t', 'void *'])
-ExportedFct('qemu_plugin_register_vcpu_insn_exec_inline_per_vcpu', 'void',
-            ['struct qemu_plugin_insn *', 'enum qemu_plugin_op',
-             'qemu_plugin_u64', 'uint64_t'])
-ExportedFct('qemu_plugin_tb_n_insns', 'size_t',
-            ['const struct qemu_plugin_tb *'])
-ExportedFct('qemu_plugin_tb_vaddr', 'uint64_t',
-            ['const struct qemu_plugin_tb *'])
-ExportedFct('qemu_plugin_tb_get_insn', 'struct qemu_plugin_insn *',
-            ['const struct qemu_plugin_tb *', 'size_t'])
-ExportedFct('qemu_plugin_insn_data', 'size_t',
-            ['const struct qemu_plugin_insn *', 'void *', 'size_t'])
-ExportedFct('qemu_plugin_insn_size', 'size_t',
-            ['const struct qemu_plugin_insn *'])
-ExportedFct('qemu_plugin_insn_vaddr', 'uint64_t',
-            ['const struct qemu_plugin_insn *'])
-ExportedFct('qemu_plugin_insn_haddr', 'void *',
-            ['const struct qemu_plugin_insn *'])
-ExportedFct('qemu_plugin_mem_size_shift', 'unsigned int',
-            ['qemu_plugin_meminfo_t'])
-ExportedFct('qemu_plugin_mem_is_sign_extended', 'bool',
-            ['qemu_plugin_meminfo_t'])
-ExportedFct('qemu_plugin_mem_is_big_endian', 'bool',
-            ['qemu_plugin_meminfo_t'])
-ExportedFct('qemu_plugin_mem_is_store', 'bool',
-            ['qemu_plugin_meminfo_t'])
-ExportedFct('qemu_plugin_get_hwaddr', 'struct qemu_plugin_hwaddr *',
-            ['qemu_plugin_meminfo_t', 'uint64_t'])
-ExportedFct('qemu_plugin_hwaddr_is_io', 'bool',
-            ['const struct qemu_plugin_hwaddr *'])
-ExportedFct('qemu_plugin_hwaddr_phys_addr', 'uint64_t',
-            ['const struct qemu_plugin_hwaddr *'])
-ExportedFct('qemu_plugin_hwaddr_device_name', 'const char *',
-            ['const struct qemu_plugin_hwaddr *'])
-ExportedFct('qemu_plugin_register_vcpu_mem_cb', 'void',
-            ['struct qemu_plugin_insn *', 'qemu_plugin_vcpu_mem_cb_t',
-             'enum qemu_plugin_cb_flags', 'enum qemu_plugin_mem_rw', 'void *'])
-ExportedFct('qemu_plugin_register_vcpu_mem_inline_per_vcpu', 'void',
-            ['struct qemu_plugin_insn *', 'enum qemu_plugin_mem_rw',
-             'enum qemu_plugin_op', 'qemu_plugin_u64', 'uint64_t'])
-ExportedFct('qemu_plugin_request_time_control', 'const void *',
-            ['qemu_plugin_id_t'])
-ExportedFct('qemu_plugin_register_time_cb', 'void',
-            ['const void *', 'qemu_plugin_time_cb_t', 'void *'])
-ExportedFct('qemu_plugin_update_ns', 'void',
-            ['const void *', 'int64_t'])
-ExportedFct('qemu_plugin_register_vcpu_syscall_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_syscall_cb_t'])
-ExportedFct('qemu_plugin_register_vcpu_syscall_ret_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_syscall_ret_cb_t'])
-ExportedFct('qemu_plugin_insn_disas', 'char *',
-            ['const struct qemu_plugin_insn *'])
-ExportedFct('qemu_plugin_insn_symbol', 'const char *',
-            ['const struct qemu_plugin_insn *'])
-ExportedFct('qemu_plugin_vcpu_for_each', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_vcpu_simple_cb_t'])
-ExportedFct('qemu_plugin_register_flush_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_simple_cb_t'])
-ExportedFct('qemu_plugin_register_atexit_cb', 'void',
-            ['qemu_plugin_id_t', 'qemu_plugin_udata_cb_t', 'void *'])
-ExportedFct('qemu_plugin_num_vcpus', 'int', [])
-ExportedFct('qemu_plugin_cpu_request_pause', 'void', ['unsigned int'])
-ExportedFct('qemu_plugin_cpu_resume', 'void', ['unsigned int'])
-ExportedFct('qemu_plugin_bql_lock', 'void', [])
-ExportedFct('qemu_plugin_bql_unlock', 'void', [])
-ExportedFct('qemu_plugin_outs', 'void', ['const char *'])
-ExportedFct('qemu_plugin_bool_parse', 'bool',
-            ['const char *', 'const char *', 'bool *'])
-ExportedFct('qemu_plugin_path_to_binary', 'const char *', [])
-ExportedFct('qemu_plugin_start_code', 'uint64_t', [])
-ExportedFct('qemu_plugin_end_code', 'uint64_t', [])
-ExportedFct('qemu_plugin_entry_code', 'uint64_t', [])
-ExportedFct('qemu_plugin_get_registers', 'GArray *', [])
-ExportedFct('qemu_plugin_read_register', 'bool',
-            ['struct qemu_plugin_register *', 'GByteArray *'])
-ExportedFct('qemu_plugin_scoreboard_new', 'struct qemu_plugin_scoreboard *',
-            ['size_t'])
-ExportedFct('qemu_plugin_scoreboard_free', 'void',
-            ['struct qemu_plugin_scoreboard *'])
-ExportedFct('qemu_plugin_scoreboard_find', 'void *',
-            ['struct qemu_plugin_scoreboard *', 'unsigned int'])
-ExportedFct('qemu_plugin_u64_add', 'void',
-            ['qemu_plugin_u64', 'unsigned int', 'uint64_t'])
-ExportedFct('qemu_plugin_u64_get', 'uint64_t',
-            ['qemu_plugin_u64', 'unsigned int'])
-ExportedFct('qemu_plugin_u64_set', 'void',
-            ['qemu_plugin_u64', 'unsigned int', 'uint64_t'])
-ExportedFct('qemu_plugin_u64_sum', 'uint64_t',
-            ['qemu_plugin_u64'])
+ExportPluginAPI()
 
 # ARM specific exports (32-bit and 64-bit)
 PrivateInclude('libqemu/wrappers/target/arm.h', arch = 'arm')

--- a/libqemu/exports/meson.build
+++ b/libqemu/exports/meson.build
@@ -1,5 +1,6 @@
 export = meson.project_source_root() / 'libqemu/exports.py'
 wrap = meson.project_source_root() / 'scripts/libqemu-wrappers.py'
+plugin_hdr = meson.project_source_root() / 'include/plugins/qemu-plugin.h'
 
 headers_to_install = [ 'typedefs.h', 'struct.h' ]
 
@@ -13,7 +14,7 @@ foreach file_name : ['fill.c',
 
     file = custom_target(file_name,
                          output: file_name,
-                         input: export,
+                         input: [ export, plugin_hdr ],
                          command: [ python, wrap, param, export ],
                          install : headers_to_install.contains(file_name),
                          install_dir : join_paths(get_option('includedir'), 'libqemu/libqemu/exports'),

--- a/scripts/libqemu-wrappers.py
+++ b/scripts/libqemu-wrappers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 import re
 
@@ -137,6 +138,82 @@ class ExportedFct:
     def gen_pub_typedef_decls():
         for f in ExportedFct.fcts.values():
             f.gen_pub_typedef_decl()
+
+
+# Type keywords that, when they directly precede the trailing identifier of a
+# parameter declaration, mean that identifier is part of the type rather than
+# the parameter name (e.g. "struct qemu_plugin_tb", "unsigned int").
+_TYPE_TAIL_KEYWORDS = ('struct', 'enum', 'union', 'const', 'unsigned', 'signed')
+
+
+def _strip_comments(s):
+    s = re.sub(r'/\*.*?\*/', '', s, flags=re.S)
+    s = re.sub(r'//.*', '', s)
+    return s
+
+
+def _arg_type(a):
+    """Reduce a C parameter declaration to its type, dropping the param name."""
+    a = a.strip()
+
+    if a == '' or a == 'void':
+        return None
+
+    # A trailing identifier with no '*' attached is the parameter name, unless
+    # it is itself the type (no preceding type text, or preceded by a keyword
+    # such as struct/enum/unsigned).
+    m = re.match(r'^(.*?)([A-Za-z_]\w*)$', a)
+    if m and '*' not in m.group(2):
+        head = m.group(1).strip()
+        if head == '' or head.endswith(_TYPE_TAIL_KEYWORDS):
+            return a
+        return head
+
+    return a
+
+
+def parse_plugin_api(header_path):
+    """Parse a QEMU plugin header and return the exported API functions.
+
+    Every function marked with the QEMU_PLUGIN_API macro is returned as a
+    (name, ret_type, [arg_types]) tuple, in declaration order.
+    """
+    with open(header_path) as f:
+        txt = _strip_comments(f.read())
+
+    fcts = []
+    for decl in re.findall(r'\bQEMU_PLUGIN_API\b(.*?);', txt, re.S):
+        # Drop a leading __attribute__((...)) before the return type.
+        decl = re.sub(r'^\s*__attribute__\s*\(\(.*?\)\)', '', decl, flags=re.S)
+        decl = re.sub(r'\s+', ' ', decl).strip()
+
+        m = re.match(r'^(.*?\b)(qemu_plugin_\w+)\s*\((.*)\)$', decl, re.S)
+        if not m:
+            # Not a function declaration (e.g. the macro definition itself).
+            continue
+
+        ret = m.group(1).strip()
+        name = m.group(2)
+        args = [t for t in (_arg_type(a) for a in m.group(3).split(','))
+                if t is not None]
+
+        fcts.append((name, ret, args))
+
+    return fcts
+
+
+def ExportPluginAPI(header = 'include/plugins/qemu-plugin.h'):
+    """Export every QEMU_PLUGIN_API function found in the plugin header.
+
+    Called from exports.py. The header is resolved relative to the repository
+    root (exports.py lives in <root>/libqemu/).
+    """
+    repo_root = os.path.join(os.path.dirname(os.path.abspath(export_file)), '..')
+    path = os.path.join(repo_root, header)
+
+    for name, ret, args in parse_plugin_api(path):
+        ExportedFct(name, ret, args)
+
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
  The qemu_plugin_* entries in libqemu/exports.py were hand-written, with
  each function's name, return type, and full parameter list duplicated
  from include/plugins/qemu-plugin.h. Any upstream change to the plugin API
  had to be mirrored by hand, and a missed update produced a silently wrong
  cast in the generated dispatch table.

  Parse the plugin header at generation time instead: emit one ExportedFct
  for every function marked QEMU_PLUGIN_API. Any upstream change to the API
  is now reflected automatically, with no edits to exports.py.

  - scripts/libqemu-wrappers.py: add parse_plugin_api() to extract the
    exported functions from the header, and the ExportPluginAPI() driver
    invoked from exports.py.
  - libqemu/exports.py: replace the hand-written plugin block with a single
    ExportPluginAPI() call.
  - libqemu/exports/meson.build: add the plugin header to the custom_target
    inputs so codegen reruns when the header changes.

  The generated LibQemuExports struct retains all previously-exported
  qemu_plugin_* members with identical signatures, and additionally exports
  the functions the manual list had omitted.
