### PR TITLE
ci: fix macOS failures due to untrusted quic homebrew tap

### DIFF
--- a/quic/install-deps.sh
+++ b/quic/install-deps.sh
@@ -46,6 +46,7 @@ else
     case "$(uname)" in
         Darwin*)
             brew tap quic/quic https://github.com/quic/homebrew-quic.git
+            brew trust quic/quic
             brew install \
                 pkg-config ninja cmake bison flex \
                 glib pixman sdl2 sdl2_image \


### PR DESCRIPTION
Signed-off-by: Matheus Tavares Bernardino <matheus.bernardino@oss.qualcomm.com>
